### PR TITLE
Reduce string memory allocation when template save

### DIFF
--- a/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
+++ b/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
+++ b/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="ClosedXML.Report" Version="0.2.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.12.3" />

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlUtils.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlUtils.cs
@@ -9,7 +9,13 @@
         /// </summary>
         internal static string EncodeXML(string value) => value == null
                   ? string.Empty
-                  : XmlEncoder.EncodeString(value).Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;").Replace("'", "&apos;");
+                  : XmlEncoder.EncodeString(value)
+                              .Replace("&", "&amp;")
+                              .Replace("<", "&lt;")
+                              .Replace(">", "&gt;")
+                              .Replace("\"", "&quot;")
+                              .Replace("'", "&apos;")
+                              .ToString();
 
         /// <summary>X=CellLetter,Y=CellNumber,ex:A1=(1,1),B2=(2,2)</summary>
         internal static string ConvertXyToCell(Tuple<int, int> xy)

--- a/src/MiniExcel/Utils/XmlEncoder.cs
+++ b/src/MiniExcel/Utils/XmlEncoder.cs
@@ -11,7 +11,7 @@
         private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
         private static readonly Regex Uppercase_X_HHHHRegex = new Regex("_(X[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
 
-        public static string EncodeString(string encodeStr)
+        public static StringBuilder EncodeString(string encodeStr)
         {
             if (encodeStr == null) return null;
 
@@ -27,7 +27,7 @@
                     sb.Append(XmlConvert.EncodeName(ch.ToString()));
             }
 
-            return sb.ToString();
+            return sb;
         }
 
         public static string DecodeString(string decodeStr)


### PR DESCRIPTION
## Benchmark

```pwsh
dotnet run -c Release -f netcoreapp3.1 -- --filter MiniExcelLibs.Benchmarks.XlsxBenchmark.MiniExcel_Template_Generate_Test
dotnet run -c Release -f net6.0 -- --filter MiniExcelLibs.Benchmarks.XlsxBenchmark.MiniExcel_Template_Generate_Test
```

### Previous - 3044e24c19bdf701256cc1f36db13e98a2e769d5

| Method                                | Toolchain     |    Mean |  StdDev |   Error |         Gen0 |       Gen1 |      Gen2 | Allocated |
| ------------------------------------- | ------------- | ------: | ------: | ------: | -----------: | ---------: | --------: | --------: |
| &#39;MiniExcel Template Generate&#39; | netcoreapp3.1 | 16.44 s | 0.465 s | 8.482 s | 1975500.0000 | 35166.6667 | 2833.3333 |  15.87 GB |
| &#39;MiniExcel Template Generate&#39; | net6.0        | 13.76 s | 0.253 s | 4.611 s | 1970666.6667 | 36500.0000 | 2833.3333 |  15.83 GB |

### Now

| Method                                | Toolchain     |    Mean |   StdDev |    Error |        Gen0 |      Gen1 |      Gen2 | Allocated |
| ------------------------------------- | ------------- | ------: | -------: | -------: | ----------: | --------: | --------: | --------: |
| &#39;MiniExcel Template Generate&#39; | netcoreapp3.1 | 7.628 s | 0.1086 s |  1.982 s | 227333.3333 | 3500.0000 | 2833.3333 |   2.25 GB |
| &#39;MiniExcel Template Generate&#39; | net6.0        | 6.680 s | 0.0213 s | 0.3892 s | 190166.6667 | 3500.0000 | 2833.3333 |   1.96 GB |

## Template save on my private project with 14,547 rows

### Previous

<img width="512" alt="prev" src="https://user-images.githubusercontent.com/24942851/192434451-dceb9222-90b0-4633-bf86-0bcb6116272f.png">

### Now

<img width="512" alt="now" src="https://user-images.githubusercontent.com/24942851/192434476-a5919990-2f2e-4e87-8634-b74b77002f40.png">
