### PR TITLE
删除包引用 System.Memory（Package delete the package reference System.memory）

### DIFF
--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -43,7 +43,4 @@
 	<ItemGroup>
 		<None Include="icon.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="System.Memory" Version="4.5.5" />
-	</ItemGroup>
 </Project>

--- a/src/MiniExcel/Utils/ImageHelper.cs
+++ b/src/MiniExcel/Utils/ImageHelper.cs
@@ -16,6 +16,43 @@
             unknown
         }
 
+#if NET45||NETSTANDARD2_0
+        public static ImageFormat GetImageFormat(byte[] bytes)
+        {
+            byte[] bmp = new byte[] { (byte)'B', (byte)'M' };            // BMP
+            byte[] gif = new byte[] { (byte)'G', (byte)'I', (byte)'F' }; // GIF
+            byte[] png = new byte[] { 137, 80, 78, 71 };                 // PNG
+            byte[] tiff = new byte[] { 73, 73, 42 };                     // TIFF
+            byte[] tiff2 = new byte[] { 77, 77, 42 };                    // TIFF
+            byte[] jpeg = new byte[] { 255, 216, 255, 224 };             // jpeg
+            byte[] jpeg2 = new byte[] { 255, 216, 255, 225 };            // jpeg canon
+
+            if (bytes.StartsWith(bmp))
+                return ImageFormat.bmp;
+
+            if (bytes.StartsWith(gif))
+                return ImageFormat.gif;
+
+            if (bytes.StartsWith(png))
+                return ImageFormat.png;
+
+            if (bytes.StartsWith(tiff))
+                return ImageFormat.tiff;
+
+            if (bytes.StartsWith(tiff2))
+                return ImageFormat.tiff;
+
+            if (bytes.StartsWith(jpeg))
+                return ImageFormat.jpg;
+
+            if (bytes.StartsWith(jpeg2))
+                return ImageFormat.jpg;
+
+            return ImageFormat.unknown;
+        }
+#endif
+
+#if  NET5_0
         public static ImageFormat GetImageFormat(ReadOnlySpan<byte> bytes)
         {
             ReadOnlySpan<byte> bmp = stackalloc byte[] { (byte)'B', (byte)'M' };            // BMP
@@ -49,6 +86,8 @@
 
             return ImageFormat.unknown;
         }
+#endif
+
     }
 
 }

--- a/src/MiniExcel/Utils/ListHelper.cs
+++ b/src/MiniExcel/Utils/ListHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace MiniExcelLibs.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public static class IEnumerableHelper
+    {
+        public static bool StartsWith<T>(this IList<T> span, IList<T> value) where T : IEquatable<T>
+        {
+            if (value.Count() == 0)
+                return true;
+
+            var b = span.Take(value.Count());
+            if (b.Count() != value.Count())
+                return false;
+
+            for (int i = 0; i < b.Count(); i++)
+                if (!span[i].Equals(value[i]))
+                    return false;
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
System.Memory 包关联的文件太多，导致在net framework 生成出来的文件过多，不太优美/mini（There are too many files associated with the System.Memory package. As a result, too many files are generated in the NET Framework ）
![image](https://user-images.githubusercontent.com/9651046/192989790-bcf19e0b-f2cf-4611-9d5e-186b424e5f46.png)
