### PR TITLE
Fix GitHub Actions .NET workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ master ]
+    branches: [ "master" ]
 
 jobs:
   build:
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
CI is broken from #439 due to 3044e24c19bdf701256cc1f36db13e98a2e769d5.
Fix this by updating .NET workflow to [latest starter workflow](https://github.com/actions/starter-workflows/blob/c820ab8a1db7c605482a2eff01ad7b5ad63bf9c8/ci/dotnet.yml).