### PR TITLE
fix: bad csv

### DIFF
--- a/src/MiniExcel/Csv/CsvConfiguration.cs
+++ b/src/MiniExcel/Csv/CsvConfiguration.cs
@@ -9,7 +9,8 @@ namespace MiniExcelLibs.Csv
         private static Encoding _defaultEncoding = new UTF8Encoding(true);
 
         public char Seperator { get; set; } = ',';
-        public string NewLine { get; set; } = "\r\n";        
+        public string NewLine { get; set; } = "\r\n";
+        public bool AlwaysQuote { get; set; } = false;
         public Func<string, string[]> SplitFn { get; set; }
         public Func<Stream, StreamReader> StreamReaderFunc { get; set; } = (stream) => new StreamReader(stream, _defaultEncoding);
         public Func<Stream, StreamWriter> StreamWriterFunc { get; set; } = (stream) => new StreamWriter(stream, _defaultEncoding);

--- a/src/MiniExcel/Csv/CsvHelpers.cs
+++ b/src/MiniExcel/Csv/CsvHelpers.cs
@@ -3,7 +3,7 @@
     internal static class CsvHelpers
     {
         /// <summary>If content contains `;, "` then use "{value}" format</summary>
-        public static string ConvertToCsvValue(string value)
+        public static string ConvertToCsvValue(string value, bool alwaysQuote)
         {
             if (value == null)
                 return string.Empty;
@@ -15,7 +15,8 @@
             else if (value.Contains(",") || value.Contains(" "))
             {
                 return $"\"{value}\"";
-            }
+            } else if (alwaysQuote)
+                return $"\"{value}\"";
             return value;
         }
     }

--- a/src/MiniExcel/Csv/CsvHelpers.cs
+++ b/src/MiniExcel/Csv/CsvHelpers.cs
@@ -2,21 +2,26 @@
 {
     internal static class CsvHelpers
     {
-        /// <summary>If content contains `;, "` then use "{value}" format</summary>
-        public static string ConvertToCsvValue(string value, bool alwaysQuote)
+        /// <summary>If content contains special characters then use "{value}" format</summary>
+        public static string ConvertToCsvValue(string value, bool alwaysQuote, char separator)
         {
             if (value == null)
                 return string.Empty;
+
             if (value.Contains("\""))
             {
                 value = value.Replace("\"", "\"\"");
                 return $"\"{value}\"";
             }
-            else if (value.Contains(",") || value.Contains(" "))
+
+            if (value.Contains(separator.ToString()) || value.Contains(" ") || value.Contains("\n") || value.Contains("\r"))
             {
                 return $"\"{value}\"";
-            } else if (alwaysQuote)
+            }
+
+            if (alwaysQuote)
                 return $"\"{value}\"";
+ 
             return value;
         }
     }

--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -1,5 +1,4 @@
-﻿using MiniExcelLibs.OpenXml;
-using MiniExcelLibs.Utils;
+﻿using MiniExcelLibs.Utils;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,7 +6,6 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -103,12 +101,12 @@ namespace MiniExcelLibs.Csv
                     {
                         if (props != null)
                         {
-                            _writer.Write(string.Join(seperator, props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName))));
+                            _writer.Write(string.Join(seperator, props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName, _configuration.AlwaysQuote))));
                             _writer.Write(newLine);
                         }
                         else if (keys.Count > 0)
                         {
-                            _writer.Write(string.Join(seperator, keys));
+                            _writer.Write(string.Join(seperator, keys.Select(s => CsvHelpers.ConvertToCsvValue(s.ToString(), _configuration.AlwaysQuote))));
                             _writer.Write(newLine);
                         }
                         else
@@ -164,7 +162,7 @@ namespace MiniExcelLibs.Csv
 
                     if (i != 0)
                         writer.Write(seperator);
-                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(columnName,null)));
+                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(columnName,null), _configuration.AlwaysQuote));
                 }
                 writer.Write(newLine);
             }
@@ -176,7 +174,7 @@ namespace MiniExcelLibs.Csv
                     var cellValue = reader.GetValue(i);
                     if (i != 0)
                         writer.Write(seperator);
-                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(cellValue,null)));
+                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(cellValue,null), _configuration.AlwaysQuote));
                 }
                 writer.Write(newLine);
             }
@@ -186,7 +184,7 @@ namespace MiniExcelLibs.Csv
         {
             if (_printHeader)
             {
-                writer.Write(string.Join(seperator, dt.Columns.Cast<DataColumn>().Select(s => CsvHelpers.ConvertToCsvValue(s.Caption ?? s.ColumnName))));
+                writer.Write(string.Join(seperator, dt.Columns.Cast<DataColumn>().Select(s => CsvHelpers.ConvertToCsvValue(s.Caption ?? s.ColumnName, _configuration.AlwaysQuote))));
                 writer.Write(newLine);
             }
             for (int i = 0; i < dt.Rows.Count; i++)
@@ -194,7 +192,7 @@ namespace MiniExcelLibs.Csv
                 var first = true;
                 for (int j = 0; j < dt.Columns.Count; j++)
                 {
-                    var cellValue = CsvHelpers.ConvertToCsvValue(ToCsvString(dt.Rows[i][j],null));
+                    var cellValue = CsvHelpers.ConvertToCsvValue(ToCsvString(dt.Rows[i][j],null), _configuration.AlwaysQuote);
                     if (!first)
                         writer.Write(seperator);
                     writer.Write(cellValue);
@@ -208,7 +206,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (var v in value)
             {
-                var values = props.Select(s => CsvHelpers.ConvertToCsvValue(ToCsvString(s?.Property.GetValue(v),s)));
+                var values = props.Select(s => CsvHelpers.ConvertToCsvValue(ToCsvString(s?.Property.GetValue(v),s), _configuration.AlwaysQuote));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }
@@ -218,7 +216,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (IDictionary v in value)
             {
-                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null)));
+                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }
@@ -228,7 +226,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (IDictionary<string, object> v in value)
             {
-                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null)));
+                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }

--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -101,12 +101,12 @@ namespace MiniExcelLibs.Csv
                     {
                         if (props != null)
                         {
-                            _writer.Write(string.Join(seperator, props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName, _configuration.AlwaysQuote))));
+                            _writer.Write(string.Join(seperator, props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName, _configuration.AlwaysQuote, _configuration.Seperator))));
                             _writer.Write(newLine);
                         }
                         else if (keys.Count > 0)
                         {
-                            _writer.Write(string.Join(seperator, keys.Select(s => CsvHelpers.ConvertToCsvValue(s.ToString(), _configuration.AlwaysQuote))));
+                            _writer.Write(string.Join(seperator, keys.Select(s => CsvHelpers.ConvertToCsvValue(s.ToString(), _configuration.AlwaysQuote, _configuration.Seperator))));
                             _writer.Write(newLine);
                         }
                         else
@@ -162,7 +162,7 @@ namespace MiniExcelLibs.Csv
 
                     if (i != 0)
                         writer.Write(seperator);
-                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(columnName,null), _configuration.AlwaysQuote));
+                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(columnName,null), _configuration.AlwaysQuote, _configuration.Seperator));
                 }
                 writer.Write(newLine);
             }
@@ -174,7 +174,7 @@ namespace MiniExcelLibs.Csv
                     var cellValue = reader.GetValue(i);
                     if (i != 0)
                         writer.Write(seperator);
-                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(cellValue,null), _configuration.AlwaysQuote));
+                    writer.Write(CsvHelpers.ConvertToCsvValue(ToCsvString(cellValue,null), _configuration.AlwaysQuote, _configuration.Seperator));
                 }
                 writer.Write(newLine);
             }
@@ -184,7 +184,7 @@ namespace MiniExcelLibs.Csv
         {
             if (_printHeader)
             {
-                writer.Write(string.Join(seperator, dt.Columns.Cast<DataColumn>().Select(s => CsvHelpers.ConvertToCsvValue(s.Caption ?? s.ColumnName, _configuration.AlwaysQuote))));
+                writer.Write(string.Join(seperator, dt.Columns.Cast<DataColumn>().Select(s => CsvHelpers.ConvertToCsvValue(s.Caption ?? s.ColumnName, _configuration.AlwaysQuote, _configuration.Seperator))));
                 writer.Write(newLine);
             }
             for (int i = 0; i < dt.Rows.Count; i++)
@@ -192,7 +192,7 @@ namespace MiniExcelLibs.Csv
                 var first = true;
                 for (int j = 0; j < dt.Columns.Count; j++)
                 {
-                    var cellValue = CsvHelpers.ConvertToCsvValue(ToCsvString(dt.Rows[i][j],null), _configuration.AlwaysQuote);
+                    var cellValue = CsvHelpers.ConvertToCsvValue(ToCsvString(dt.Rows[i][j],null), _configuration.AlwaysQuote, _configuration.Seperator);
                     if (!first)
                         writer.Write(seperator);
                     writer.Write(cellValue);
@@ -206,7 +206,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (var v in value)
             {
-                var values = props.Select(s => CsvHelpers.ConvertToCsvValue(ToCsvString(s?.Property.GetValue(v),s), _configuration.AlwaysQuote));
+                var values = props.Select(s => CsvHelpers.ConvertToCsvValue(ToCsvString(s?.Property.GetValue(v),s), _configuration.AlwaysQuote, _configuration.Seperator));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }
@@ -216,7 +216,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (IDictionary v in value)
             {
-                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote));
+                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote, _configuration.Seperator));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }
@@ -226,7 +226,7 @@ namespace MiniExcelLibs.Csv
         {
             foreach (IDictionary<string, object> v in value)
             {
-                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote));
+                var values = keys.Select(key => CsvHelpers.ConvertToCsvValue(ToCsvString(v[key],null), _configuration.AlwaysQuote, _configuration.Seperator));
                 writer.Write(string.Join(seperator, values));
                 writer.Write(newLine);
             }

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -45,6 +45,23 @@ namespace MiniExcelLibs.Tests
         }
 
         [Fact]
+        public void AlwaysQuoteTest()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
+            var values = new List<Dictionary<string, object>>()
+                {
+                    new Dictionary<string,object>{{ "a", @"""<>+-*//}{\\n" }, { "b", 1234567890 },{ "c", true },{ "d", new DateTime(2021, 1, 1) } },
+                    new Dictionary<string,object>{{ "a", @"<test>Hello World</test>" }, { "b", -1234567890 },{ "c", false },{ "d", new DateTime(2021, 1, 2) } },
+                };
+            MiniExcel.SaveAs(path, values,configuration: new MiniExcelLibs.Csv.CsvConfiguration() {AlwaysQuote = true});
+            var expected = @"""a"",""b"",""c"",""d""
+""""""<>+-*//}{\\n"",""1234567890"",""True"",""2021-01-01 00:00:00""
+""<test>Hello World</test>"",""-1234567890"",""False"",""2021-01-02 00:00:00""
+";
+            Assert.Equal(expected, File.ReadAllText(path));
+        }
+
+        [Fact]
         public void SaveAsByDictionary()
         {
             {

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -62,6 +62,19 @@ namespace MiniExcelLibs.Tests
         }
 
         [Fact]
+        public void QuoteSpecialCharacters()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
+            var values = new List<Dictionary<string, object>>()
+                {
+                    new Dictionary<string,object>{{ "a", @"potato,banana" }, { "b", "text\ntest" },{ "c", "text\rpotato" },{ "d", new DateTime(2021, 1, 1) } },
+                };
+            MiniExcel.SaveAs(path, values,configuration: new MiniExcelLibs.Csv.CsvConfiguration());
+            var expected = "a,b,c,d\r\n\"potato,banana\",\"text\ntest\",\"text\rpotato\",\"2021-01-01 00:00:00\"\r\n";
+            Assert.Equal(expected, File.ReadAllText(path));
+        }
+
+        [Fact]
         public void SaveAsByDictionary()
         {
             {


### PR DESCRIPTION
Hello o/

In this PR, I added a new feature and fixed a possible bug during the generation of the CSV:

### feat: add support to force all fields being quoted

I did this because I had to generate a CSV from an XLSX file and the output was an invalid CSV, after inspecting, I discovered if I quote all fields, the CSV will be valid.

This issue probably has some connection with the next fix.

### fix: quote delimiter and also \n and \r

Based on this library:

https://github.com/ryu1kn/csv-writer/blob/11c66494affbd559d5869201ade16fe2cc1b37e2/src/lib/field-stringifier.ts#L27-L29

I added more cases to cover during the value quote, I suspect because of this issue that my CSV previously was generated as an invalid CSV.
Also, I include the CSV headers to be escaped.

