### PR TITLE
Fix EnableWriteNullValueCell null error

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ File content before and after merge:
 
 #### 13. Skip null values
 
-Default behaviour:
+New explicit option to write empty cells for null values:
 
 ```csharp
 DataTable dt = new DataTable();
@@ -568,7 +568,39 @@ dr["Name3"] = "told me.";
 
 dt.Rows.Add(dr);
 
-MiniExcel.SaveAs(@"C:\temp\Book1.xlsx", dt);
+OpenXmlConfiguration configuration = new OpenXmlConfiguration()
+{
+     EnableWriteNullValueCell = true // Default value.
+};
+
+MiniExcel.SaveAs(@"C:\temp\Book1.xlsx", dt, configuration: configuration);
+```
+
+![image](https://user-images.githubusercontent.com/31481586/241419455-3c0aec8a-4e5f-4d83-b7ec-6572124c165d.png)
+
+```xml
+<x:row r="2">
+    <x:c r="A2" t ="str" s="2">
+        <x:v>Somebody once</x:v>
+    </x:c>
+    <x:c r="B2" s="2"></x:c>
+    <x:c r="C2" t ="str" s="2">
+        <x:v>told me.</x:v>
+    </x:c>
+</x:row>
+```
+
+Previous behavior:
+
+```csharp
+/* ... */
+
+OpenXmlConfiguration configuration = new OpenXmlConfiguration()
+{
+     EnableWriteNullValueCell = false // Default value is true.
+};
+
+MiniExcel.SaveAs(@"C:\temp\Book1.xlsx", dt, configuration: configuration);
 ```
 
 ![image](https://user-images.githubusercontent.com/31481586/241419441-c4f27e8f-3f87-46db-a10f-08665864c874.png)
@@ -581,32 +613,6 @@ MiniExcel.SaveAs(@"C:\temp\Book1.xlsx", dt);
     <x:c r="B2" t ="str" s="2">
         <x:v></x:v>
     </x:c>
-    <x:c r="C2" t ="str" s="2">
-        <x:v>told me.</x:v>
-    </x:c>
-</x:row>
-```
-
-Result using new option:
-
-```csharp
-OpenXmlConfiguration configuration = new OpenXmlConfiguration()
-{
-     WriteNullValues = false // Default value is true.
-};
-
-MiniExcel.SaveAs(@"C:\temp\Book1.xlsx", dt, configuration: configuration);
-```
-
-![image](https://user-images.githubusercontent.com/31481586/241419455-3c0aec8a-4e5f-4d83-b7ec-6572124c165d.png)
-
-
-```xml
-<x:row r="2">
-    <x:c r="A2" t ="str" s="2">
-        <x:v>Somebody once</x:v>
-    </x:c>
-    <x:c r="B2" s="2"></x:c>
     <x:c r="C2" t ="str" s="2">
         <x:v>told me.</x:v>
     </x:c>

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -397,8 +397,9 @@ namespace MiniExcelLibs.OpenXml
         {
             var columname = ExcelOpenXmlUtils.ConvertXyToCell(cellIndex, rowIndex);
             var s = "2";
+            var valueIsNull = value is null || value is DBNull;
 
-            if (_configuration.EnableWriteNullValueCell && (value is null || value is DBNull))
+            if (_configuration.EnableWriteNullValueCell && valueIsNull)
             {
                 writer.Write($"<x:c r=\"{columname}\" s=\"{s}\"></x:c>");
                 return;
@@ -407,134 +408,135 @@ namespace MiniExcelLibs.OpenXml
             var v = string.Empty;
             var t = "str";
 
-            if (value is string str)
-            {
-                v = ExcelOpenXmlUtils.EncodeXML(str);
-            }
-            else if (p?.ExcelFormat != null && value is IFormattable formattableValue)
-            {
-                var formattedStr = formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
-                v = ExcelOpenXmlUtils.EncodeXML(formattedStr);
-            }
-            else
-            {
-                Type type = null;
-                if (p == null || p.Key != null)
+            if (!valueIsNull)
+                if (value is string str)
                 {
-                    // TODO: need to optimize 
-                    // Dictionary need to check type every time, so it's slow..
-                    type = value.GetType();
-                    type = Nullable.GetUnderlyingType(type) ?? type;
+                    v = ExcelOpenXmlUtils.EncodeXML(str);
+                }
+                else if (p?.ExcelFormat != null && value is IFormattable formattableValue)
+                {
+                    var formattedStr = formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
+                    v = ExcelOpenXmlUtils.EncodeXML(formattedStr);
                 }
                 else
                 {
-                    type = p.ExcludeNullableType; //sometime it doesn't need to re-get type like prop
-                }
-
-                if (type.IsEnum)
-                {
-                    t = "str";
-                    var description = CustomPropertyHelper.DescriptionAttr(type, value); //TODO: need to optimze
-                    if (description != null)
-                        v = description;
-                    else
-                        v = value.ToString();
-                }
-                else if (TypeHelper.IsNumericType(type))
-                {
-                    if (_configuration.Culture != CultureInfo.InvariantCulture)
-                        t = "str"; //TODO: add style format
-                    else
-                        t = "n";
-
-                    if (type.IsAssignableFrom(typeof(decimal)))
-                        v = ((decimal)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Int32)))
-                        v = ((Int32)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Double)))
-                        v = ((Double)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Int64)))
-                        v = ((Int64)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(UInt32)))
-                        v = ((UInt32)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(UInt16)))
-                        v = ((UInt16)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(UInt64)))
-                        v = ((UInt64)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Int16)))
-                        v = ((Int16)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Single)))
-                        v = ((Single)value).ToString(_configuration.Culture);
-                    else if (type.IsAssignableFrom(typeof(Single)))
-                        v = ((Single)value).ToString(_configuration.Culture);
-                    else
-                        v = (decimal.Parse(value.ToString())).ToString(_configuration.Culture);
-                }
-                else if (type == typeof(bool))
-                {
-                    t = "b";
-                    v = (bool)value ? "1" : "0";
-                }
-                else if (type == typeof(byte[]) && _configuration.EnableConvertByteArray)
-                {
-                    var bytes = (byte[])value;
-                    if (bytes != null)
+                    Type type = null;
+                    if (p == null || p.Key != null)
                     {
-                        // TODO: Setting configuration because it might have high cost?
-                        var format = ImageHelper.GetImageFormat(bytes);
-                        //it can't insert to zip first to avoid cache image to memory
-                        //because sheet xml is opening.. https://github.com/shps951023/MiniExcel/issues/304#issuecomment-1017031691
-                        //int rowIndex, int cellIndex
-                        var file = new FileDto()
+                        // TODO: need to optimize 
+                        // Dictionary need to check type every time, so it's slow..
+                        type = value.GetType();
+                        type = Nullable.GetUnderlyingType(type) ?? type;
+                    }
+                    else
+                    {
+                        type = p.ExcludeNullableType; //sometime it doesn't need to re-get type like prop
+                    }
+
+                    if (type.IsEnum)
+                    {
+                        t = "str";
+                        var description = CustomPropertyHelper.DescriptionAttr(type, value); //TODO: need to optimze
+                        if (description != null)
+                            v = description;
+                        else
+                            v = value.ToString();
+                    }
+                    else if (TypeHelper.IsNumericType(type))
+                    {
+                        if (_configuration.Culture != CultureInfo.InvariantCulture)
+                            t = "str"; //TODO: add style format
+                        else
+                            t = "n";
+
+                        if (type.IsAssignableFrom(typeof(decimal)))
+                            v = ((decimal)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Int32)))
+                            v = ((Int32)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Double)))
+                            v = ((Double)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Int64)))
+                            v = ((Int64)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(UInt32)))
+                            v = ((UInt32)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(UInt16)))
+                            v = ((UInt16)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(UInt64)))
+                            v = ((UInt64)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Int16)))
+                            v = ((Int16)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Single)))
+                            v = ((Single)value).ToString(_configuration.Culture);
+                        else if (type.IsAssignableFrom(typeof(Single)))
+                            v = ((Single)value).ToString(_configuration.Culture);
+                        else
+                            v = (decimal.Parse(value.ToString())).ToString(_configuration.Culture);
+                    }
+                    else if (type == typeof(bool))
+                    {
+                        t = "b";
+                        v = (bool)value ? "1" : "0";
+                    }
+                    else if (type == typeof(byte[]) && _configuration.EnableConvertByteArray)
+                    {
+                        var bytes = (byte[])value;
+                        if (bytes != null)
                         {
-                            Byte = bytes,
-                            RowIndex = rowIndex,
-                            CellIndex = cellIndex,
-                            SheetId = currentSheetIndex
-                        };
-                        if (format != ImageFormat.unknown)
+                            // TODO: Setting configuration because it might have high cost?
+                            var format = ImageHelper.GetImageFormat(bytes);
+                            //it can't insert to zip first to avoid cache image to memory
+                            //because sheet xml is opening.. https://github.com/shps951023/MiniExcel/issues/304#issuecomment-1017031691
+                            //int rowIndex, int cellIndex
+                            var file = new FileDto()
+                            {
+                                Byte = bytes,
+                                RowIndex = rowIndex,
+                                CellIndex = cellIndex,
+                                SheetId = currentSheetIndex
+                            };
+                            if (format != ImageFormat.unknown)
+                            {
+                                file.Extension = format.ToString();
+                                file.IsImage = true;
+                            }
+                            else
+                            {
+                                file.Extension = "bin";
+                            }
+                            _files.Add(file);
+
+                            //TODO:Convert to base64
+                            var base64 = $"@@@fileid@@@,{file.Path}";
+                            v = ExcelOpenXmlUtils.EncodeXML(base64);
+                            s = "4";
+                        }
+                    }
+                    else if (type == typeof(DateTime))
+                    {
+                        if (_configuration.Culture != CultureInfo.InvariantCulture)
                         {
-                            file.Extension = format.ToString();
-                            file.IsImage = true;
+                            t = "str";
+                            v = ((DateTime)value).ToString(_configuration.Culture);
+                        }
+                        else if (p == null || p.ExcelFormat == null)
+                        {
+                            t = null;
+                            s = "3";
+                            v = ((DateTime)value).ToOADate().ToString(CultureInfo.InvariantCulture);
                         }
                         else
                         {
-                            file.Extension = "bin";
+                            // TODO: now it'll lose date type information
+                            t = "str";
+                            v = ((DateTime)value).ToString(p.ExcelFormat, _configuration.Culture);
                         }
-                        _files.Add(file);
-
-                        //TODO:Convert to base64
-                        var base64 = $"@@@fileid@@@,{file.Path}";
-                        v = ExcelOpenXmlUtils.EncodeXML(base64);
-                        s = "4";
-                    }
-                }
-                else if (type == typeof(DateTime))
-                {
-                    if (_configuration.Culture != CultureInfo.InvariantCulture)
-                    {
-                        t = "str";
-                        v = ((DateTime)value).ToString(_configuration.Culture);
-                    }
-                    else if (p == null || p.ExcelFormat == null)
-                    {
-                        t = null;
-                        s = "3";
-                        v = ((DateTime)value).ToOADate().ToString(CultureInfo.InvariantCulture);
                     }
                     else
                     {
-                        // TODO: now it'll lose date type information
-                        t = "str";
-                        v = ((DateTime)value).ToString(p.ExcelFormat, _configuration.Culture);
+                        //TODO: _configuration.Culture
+                        v = ExcelOpenXmlUtils.EncodeXML(value.ToString());
                     }
                 }
-                else
-                {
-                    //TODO: _configuration.Culture
-                    v = ExcelOpenXmlUtils.EncodeXML(value.ToString());
-                }
-            }
 
             if (v != null && (v.StartsWith(" ", StringComparison.Ordinal) || v.EndsWith(" ", StringComparison.Ordinal))) /*Prefix and suffix blank space will lost after SaveAs #294*/
                 writer.Write($"<x:c r=\"{columname}\" {(t == null ? "" : $"t =\"{t}\"")} s=\"{s}\" xml:space=\"preserve\"><x:v>{v}</x:v></x:c>");

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -408,135 +408,138 @@ namespace MiniExcelLibs.OpenXml
             var v = string.Empty;
             var t = "str";
 
-            if (!valueIsNull)
-                if (value is string str)
+            if (valueIsNull)
+            {
+
+            }
+            else if (value is string str)
+            {
+                v = ExcelOpenXmlUtils.EncodeXML(str);
+            }
+            else if (p?.ExcelFormat != null && value is IFormattable formattableValue)
+            {
+                var formattedStr = formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
+                v = ExcelOpenXmlUtils.EncodeXML(formattedStr);
+            }
+            else
+            {
+                Type type = null;
+                if (p == null || p.Key != null)
                 {
-                    v = ExcelOpenXmlUtils.EncodeXML(str);
-                }
-                else if (p?.ExcelFormat != null && value is IFormattable formattableValue)
-                {
-                    var formattedStr = formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
-                    v = ExcelOpenXmlUtils.EncodeXML(formattedStr);
+                    // TODO: need to optimize 
+                    // Dictionary need to check type every time, so it's slow..
+                    type = value.GetType();
+                    type = Nullable.GetUnderlyingType(type) ?? type;
                 }
                 else
                 {
-                    Type type = null;
-                    if (p == null || p.Key != null)
-                    {
-                        // TODO: need to optimize 
-                        // Dictionary need to check type every time, so it's slow..
-                        type = value.GetType();
-                        type = Nullable.GetUnderlyingType(type) ?? type;
-                    }
+                    type = p.ExcludeNullableType; //sometime it doesn't need to re-get type like prop
+                }
+
+                if (type.IsEnum)
+                {
+                    t = "str";
+                    var description = CustomPropertyHelper.DescriptionAttr(type, value); //TODO: need to optimze
+                    if (description != null)
+                        v = description;
                     else
-                    {
-                        type = p.ExcludeNullableType; //sometime it doesn't need to re-get type like prop
-                    }
-
-                    if (type.IsEnum)
-                    {
-                        t = "str";
-                        var description = CustomPropertyHelper.DescriptionAttr(type, value); //TODO: need to optimze
-                        if (description != null)
-                            v = description;
-                        else
-                            v = value.ToString();
-                    }
-                    else if (TypeHelper.IsNumericType(type))
-                    {
-                        if (_configuration.Culture != CultureInfo.InvariantCulture)
-                            t = "str"; //TODO: add style format
-                        else
-                            t = "n";
-
-                        if (type.IsAssignableFrom(typeof(decimal)))
-                            v = ((decimal)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Int32)))
-                            v = ((Int32)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Double)))
-                            v = ((Double)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Int64)))
-                            v = ((Int64)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(UInt32)))
-                            v = ((UInt32)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(UInt16)))
-                            v = ((UInt16)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(UInt64)))
-                            v = ((UInt64)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Int16)))
-                            v = ((Int16)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Single)))
-                            v = ((Single)value).ToString(_configuration.Culture);
-                        else if (type.IsAssignableFrom(typeof(Single)))
-                            v = ((Single)value).ToString(_configuration.Culture);
-                        else
-                            v = (decimal.Parse(value.ToString())).ToString(_configuration.Culture);
-                    }
-                    else if (type == typeof(bool))
-                    {
-                        t = "b";
-                        v = (bool)value ? "1" : "0";
-                    }
-                    else if (type == typeof(byte[]) && _configuration.EnableConvertByteArray)
-                    {
-                        var bytes = (byte[])value;
-                        if (bytes != null)
-                        {
-                            // TODO: Setting configuration because it might have high cost?
-                            var format = ImageHelper.GetImageFormat(bytes);
-                            //it can't insert to zip first to avoid cache image to memory
-                            //because sheet xml is opening.. https://github.com/shps951023/MiniExcel/issues/304#issuecomment-1017031691
-                            //int rowIndex, int cellIndex
-                            var file = new FileDto()
-                            {
-                                Byte = bytes,
-                                RowIndex = rowIndex,
-                                CellIndex = cellIndex,
-                                SheetId = currentSheetIndex
-                            };
-                            if (format != ImageFormat.unknown)
-                            {
-                                file.Extension = format.ToString();
-                                file.IsImage = true;
-                            }
-                            else
-                            {
-                                file.Extension = "bin";
-                            }
-                            _files.Add(file);
-
-                            //TODO:Convert to base64
-                            var base64 = $"@@@fileid@@@,{file.Path}";
-                            v = ExcelOpenXmlUtils.EncodeXML(base64);
-                            s = "4";
-                        }
-                    }
-                    else if (type == typeof(DateTime))
-                    {
-                        if (_configuration.Culture != CultureInfo.InvariantCulture)
-                        {
-                            t = "str";
-                            v = ((DateTime)value).ToString(_configuration.Culture);
-                        }
-                        else if (p == null || p.ExcelFormat == null)
-                        {
-                            t = null;
-                            s = "3";
-                            v = ((DateTime)value).ToOADate().ToString(CultureInfo.InvariantCulture);
-                        }
-                        else
-                        {
-                            // TODO: now it'll lose date type information
-                            t = "str";
-                            v = ((DateTime)value).ToString(p.ExcelFormat, _configuration.Culture);
-                        }
-                    }
+                        v = value.ToString();
+                }
+                else if (TypeHelper.IsNumericType(type))
+                {
+                    if (_configuration.Culture != CultureInfo.InvariantCulture)
+                        t = "str"; //TODO: add style format
                     else
+                        t = "n";
+
+                    if (type.IsAssignableFrom(typeof(decimal)))
+                        v = ((decimal)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Int32)))
+                        v = ((Int32)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Double)))
+                        v = ((Double)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Int64)))
+                        v = ((Int64)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(UInt32)))
+                        v = ((UInt32)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(UInt16)))
+                        v = ((UInt16)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(UInt64)))
+                        v = ((UInt64)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Int16)))
+                        v = ((Int16)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Single)))
+                        v = ((Single)value).ToString(_configuration.Culture);
+                    else if (type.IsAssignableFrom(typeof(Single)))
+                        v = ((Single)value).ToString(_configuration.Culture);
+                    else
+                        v = (decimal.Parse(value.ToString())).ToString(_configuration.Culture);
+                }
+                else if (type == typeof(bool))
+                {
+                    t = "b";
+                    v = (bool)value ? "1" : "0";
+                }
+                else if (type == typeof(byte[]) && _configuration.EnableConvertByteArray)
+                {
+                    var bytes = (byte[])value;
+                    if (bytes != null)
                     {
-                        //TODO: _configuration.Culture
-                        v = ExcelOpenXmlUtils.EncodeXML(value.ToString());
+                        // TODO: Setting configuration because it might have high cost?
+                        var format = ImageHelper.GetImageFormat(bytes);
+                        //it can't insert to zip first to avoid cache image to memory
+                        //because sheet xml is opening.. https://github.com/shps951023/MiniExcel/issues/304#issuecomment-1017031691
+                        //int rowIndex, int cellIndex
+                        var file = new FileDto()
+                        {
+                            Byte = bytes,
+                            RowIndex = rowIndex,
+                            CellIndex = cellIndex,
+                            SheetId = currentSheetIndex
+                        };
+                        if (format != ImageFormat.unknown)
+                        {
+                            file.Extension = format.ToString();
+                            file.IsImage = true;
+                        }
+                        else
+                        {
+                            file.Extension = "bin";
+                        }
+                        _files.Add(file);
+
+                        //TODO:Convert to base64
+                        var base64 = $"@@@fileid@@@,{file.Path}";
+                        v = ExcelOpenXmlUtils.EncodeXML(base64);
+                        s = "4";
                     }
                 }
+                else if (type == typeof(DateTime))
+                {
+                    if (_configuration.Culture != CultureInfo.InvariantCulture)
+                    {
+                        t = "str";
+                        v = ((DateTime)value).ToString(_configuration.Culture);
+                    }
+                    else if (p == null || p.ExcelFormat == null)
+                    {
+                        t = null;
+                        s = "3";
+                        v = ((DateTime)value).ToOADate().ToString(CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        // TODO: now it'll lose date type information
+                        t = "str";
+                        v = ((DateTime)value).ToString(p.ExcelFormat, _configuration.Culture);
+                    }
+                }
+                else
+                {
+                    //TODO: _configuration.Culture
+                    v = ExcelOpenXmlUtils.EncodeXML(value.ToString());
+                }
+            }
 
             if (v != null && (v.StartsWith(" ", StringComparison.Ordinal) || v.EndsWith(" ", StringComparison.Ordinal))) /*Prefix and suffix blank space will lost after SaveAs #294*/
                 writer.Write($"<x:c r=\"{columname}\" {(t == null ? "" : $"t =\"{t}\"")} s=\"{s}\" xml:space=\"preserve\"><x:v>{v}</x:v></x:c>");

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -516,6 +516,15 @@ namespace MiniExcelLibs.Tests
             var rows = MiniExcel.Query<TestIssue310Dto>(path).ToList();
         }
 
+        [Fact]
+        public void TestIssue310Fix497()
+        {
+            var path = PathHelper.GetTempFilePath();
+            var value = new[] { new TestIssue310Dto { V1 = null }, new TestIssue310Dto { V1 = 2 } };
+            MiniExcel.SaveAs(path, value, configuration: new OpenXmlConfiguration() { EnableWriteNullValueCell = false });
+            var rows = MiniExcel.Query<TestIssue310Dto>(path).ToList();
+        }
+
         public class TestIssue310Dto
         {
             public int? V1 { get; set; }


### PR DESCRIPTION
Removing first condition caused `if` statement to fall into `else` block resulting in `NullReferenceException` if `value` is null and `EnableWriteNullValueCells` is set to `false`.
Apologies for making this mistake.