### PR TITLE
Make use of dynamic columns when generating sheet by IDataReader to change columns names & widths

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -609,17 +609,26 @@ namespace MiniExcelLibs.OpenXml
                     writer.Write("                              />"); // end of code will be replaced
                 }
 
+                var props = new List<ExcelColumnInfo>();
+                for (var i = 0; i < reader.FieldCount; i++)
+                {
+                    var columnName = reader.GetName(i);
+                    var prop = GetColumnInfosForIDataReader(columnName);
+                    props.Add(prop);
+                }
+
+                WriteColumnsWidths(writer, props);
+                
                 writer.Write("<x:sheetData>");
                 int fieldCount = reader.FieldCount;
                 if (_printHeader)
                 {
                     writer.Write($"<x:row r=\"{yIndex}\">");
                     xIndex = xy.Item1;
-                    for (int i = 0; i < fieldCount; i++)
+                    foreach (var p in props)
                     {
                         var r = ExcelOpenXmlUtils.ConvertXyToCell(xIndex, yIndex);
-                        var columnName = reader.GetName(i);
-                        WriteC(writer, r, columnName);
+                        WriteC(writer, r, columnName: p.ExcelColumnName);
                         xIndex++;
                     }
                     writer.Write($"</x:row>");
@@ -653,6 +662,54 @@ namespace MiniExcelLibs.OpenXml
             }
         }
 
+        private ExcelColumnInfo GetColumnInfosForIDataReader(string columnName)
+        {
+            var prop = new ExcelColumnInfo
+            {
+                ExcelColumnName = columnName,
+                Key = columnName
+            };
+
+            if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0) 
+                return prop;
+            
+            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => _.Key == columnName);
+            if (dynamicColumn == null || dynamicColumn.Ignore)
+            {
+                return prop;
+            }
+
+            prop.Nullable = true;
+            //prop.ExcludeNullableType = item2[key]?.GetType();
+            if (dynamicColumn.Format != null)
+                prop.ExcelFormat = dynamicColumn.Format;
+            if (dynamicColumn.Aliases != null)
+                prop.ExcelColumnAliases = dynamicColumn.Aliases;
+            if (dynamicColumn.IndexName != null)
+                prop.ExcelIndexName = dynamicColumn.IndexName;
+            prop.ExcelColumnIndex = dynamicColumn.Index;
+            if (dynamicColumn.Name != null)
+                prop.ExcelColumnName = dynamicColumn.Name;
+            prop.ExcelColumnWidth = dynamicColumn.Width;
+
+            return prop;
+        }
+
+        private static void WriteColumnsWidths(MiniExcelStreamWriter writer, IEnumerable<ExcelColumnInfo> props)
+        {
+            var ecwProps = props.Where(x => x?.ExcelColumnWidth != null).ToList();
+            if (ecwProps.Count <= 0)
+                return;
+            writer.Write($@"<x:cols>");
+            foreach (var p in ecwProps)
+            {
+                writer.Write(
+                    $@"<x:col min=""{p.ExcelColumnIndex + 1}"" max=""{p.ExcelColumnIndex + 1}"" width=""{p.ExcelColumnWidth}"" customWidth=""1"" />");
+            }
+
+            writer.Write($@"</x:cols>");
+        }
+        
         private static void WriteC(MiniExcelStreamWriter writer, string r, string columnName)
         {
             writer.Write($"<x:c r=\"{r}\" t=\"str\" s=\"1\">");


### PR DESCRIPTION
Currently generation of xlsx via IDataReader does not use a dynamic columns configuration to change  columns names & widths of generated xlsx. This PR adds such an option to it.

Using other methods to get data for excel, which are using dynamic columns, are not always an options when excel is huge and must be processed with the smallest amount of memory used.
