### PR TITLE
Throw custom exception when CSV column not found

### DIFF
--- a/src/MiniExcel/Exceptions/ExcelColumnNotFoundException.cs
+++ b/src/MiniExcel/Exceptions/ExcelColumnNotFoundException.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace MiniExcelLibs.Exceptions
+{
+    public class ExcelColumnNotFoundException : KeyNotFoundException
+    {
+        public string ColumnName { get; set; }
+        public string[] ColumnAliases { get; }
+        public string ColumnIndex { get; set; }
+        public int RowIndex { get; set; }
+        public IDictionary<string, int> Headers { get; }
+        public object RowValues { get; set; }
+
+        public ExcelColumnNotFoundException(string columnIndex, string columnName, string[] columnAliases, int rowIndex, IDictionary<string, int> headers, object value, string message) : base(message)
+        {
+            ColumnIndex = columnIndex;
+            ColumnName = columnName;
+            ColumnAliases = columnAliases;
+            RowIndex = rowIndex;
+            Headers = headers;
+            RowValues = value;
+        }
+    }
+}


### PR DESCRIPTION
If there is missing data in a CSV file row, the application throws a KeyNotFoundException error. This PR adds a special type of exception that provides more detailed information about which row and field encountered issues with loading data.