### PR TITLE
Allow ampersand in sheet names

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -870,11 +870,11 @@ namespace MiniExcelLibs.OpenXml
                     sheetId++;
                     if (string.IsNullOrEmpty(s.State))
                     {
-                        workbookXml.AppendLine($@"<x:sheet name=""{s.Name}"" sheetId=""{sheetId}"" r:id=""{s.ID}"" />");
+                        workbookXml.AppendLine($@"<x:sheet name=""{ExcelOpenXmlUtils.EncodeXML(s.Name)}"" sheetId=""{sheetId}"" r:id=""{s.ID}"" />");
                     }
                     else
                     {
-                        workbookXml.AppendLine($@"<x:sheet name=""{s.Name}"" sheetId=""{sheetId}"" state=""{s.State}"" r:id=""{s.ID}"" />");
+                        workbookXml.AppendLine($@"<x:sheet name=""{ExcelOpenXmlUtils.EncodeXML(s.Name)}"" sheetId=""{sheetId}"" state=""{s.State}"" r:id=""{s.ID}"" />");
                     }
                     workbookRelsXml.AppendLine($@"<Relationship Type=""http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"" Target=""/{s.Path}"" Id=""{s.ID}"" />");
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -178,7 +178,7 @@ namespace MiniExcelLibs.OpenXml
                 {
                     mode = "IDictionary";
                     props = GetDictionaryColumnInfo(null, dic);
-                    //maxColumnIndex = dic.Keys.Count; 
+                    //maxColumnIndex = dic.Keys.Count;
                     maxColumnIndex = props.Count; // why not using keys, because ignore attribute ![image](https://user-images.githubusercontent.com/12729184/163686902-286abb70-877b-4e84-bd3b-001ad339a84a.png)
                 }
                 else
@@ -190,7 +190,7 @@ namespace MiniExcelLibs.OpenXml
             writer.Write($@"<?xml version=""1.0"" encoding=""utf-8""?><x:worksheet xmlns:r=""http://schemas.openxmlformats.org/officeDocument/2006/relationships"" xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"" >");
 
             long dimensionWritePosition = 0;
-            
+
             // We can write the dimensions directly if the row count is known
             if (_configuration.FastMode && rowCount == null)
             {
@@ -328,7 +328,7 @@ namespace MiniExcelLibs.OpenXml
             p.ExcelColumnName = key?.ToString();
             p.Key = key;
             // TODO:Dictionary value type is not fiexed
-            //var _t = 
+            //var _t =
             //var gt = Nullable.GetUnderlyingType(p.PropertyType);
             var isIgnore = false;
             if (_configuration.DynamicColumns != null && _configuration.DynamicColumns.Length > 0)
@@ -449,7 +449,7 @@ namespace MiniExcelLibs.OpenXml
                 Type type = null;
                 if (p == null || p.Key != null)
                 {
-                    // TODO: need to optimize 
+                    // TODO: need to optimize
                     // Dictionary need to check type every time, so it's slow..
                     type = value.GetType();
                     type = Nullable.GetUnderlyingType(type) ?? type;
@@ -655,7 +655,7 @@ namespace MiniExcelLibs.OpenXml
                 maxColumnIndex = props.Count;
 
                 WriteColumnsWidths(writer, props);
-                
+
                 writer.Write("<x:sheetData>");
                 int fieldCount = reader.FieldCount;
                 if (_printHeader)
@@ -701,9 +701,9 @@ namespace MiniExcelLibs.OpenXml
                 Key = columnName
             };
 
-            if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0) 
+            if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0)
                 return prop;
-            
+
             var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => _.Key == columnName);
             if (dynamicColumn == null || dynamicColumn.Ignore)
             {
@@ -760,12 +760,12 @@ namespace MiniExcelLibs.OpenXml
             foreach (var p in ecwProps)
             {
                 writer.Write(
-                    $@"<x:col min=""{p.ExcelColumnIndex + 1}"" max=""{p.ExcelColumnIndex + 1}"" width=""{p.ExcelColumnWidth}"" customWidth=""1"" />");
+                    $@"<x:col min=""{p.ExcelColumnIndex + 1}"" max=""{p.ExcelColumnIndex + 1}"" width=""{p.ExcelColumnWidth?.ToString(CultureInfo.InvariantCulture)}"" customWidth=""1"" />");
             }
 
             writer.Write($@"</x:cols>");
         }
-        
+
         private static void WriteC(MiniExcelStreamWriter writer, string r, string columnName)
         {
             writer.Write($"<x:c r=\"{r}\" t=\"str\" s=\"1\">");
@@ -784,7 +784,7 @@ namespace MiniExcelLibs.OpenXml
                 }
             }
 
-            // styles.xml 
+            // styles.xml
             {
                 var styleXml = string.Empty;
 
@@ -878,7 +878,7 @@ namespace MiniExcelLibs.OpenXml
                     }
                     workbookRelsXml.AppendLine($@"<Relationship Type=""http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"" Target=""/{s.Path}"" Id=""{s.ID}"" />");
 
-                    //TODO: support multiple drawing 
+                    //TODO: support multiple drawing
                     //TODO: ../drawings/drawing1.xml or /xl/drawings/drawing1.xml
                     var sheetRelsXml = $@"<Relationship Type=""http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"" Target=""../drawings/drawing{sheetId}.xml"" Id=""drawing{sheetId}"" />";
                     CreateZipEntry($"xl/worksheets/_rels/sheet{s.SheetIdx}.xml.rels", "",
@@ -890,7 +890,7 @@ namespace MiniExcelLibs.OpenXml
                     _defaultWorkbookXmlRels.Replace("{{sheets}}", workbookRelsXml.ToString()));
             }
 
-            //[Content_Types].xml 
+            //[Content_Types].xml
             {
                 var sb = new StringBuilder(@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?><Types xmlns=""http://schemas.openxmlformats.org/package/2006/content-types""><Default ContentType=""application/vnd.openxmlformats-officedocument.spreadsheetml.printerSettings"" Extension=""bin""/><Default ContentType=""application/xml"" Extension=""xml""/><Default ContentType=""image/jpeg"" Extension=""jpg""/><Default ContentType=""image/png"" Extension=""png""/><Default ContentType=""image/gif"" Extension=""gif""/><Default ContentType=""application/vnd.openxmlformats-package.relationships+xml"" Extension=""rels""/>");
                 foreach (var p in _zipDictionary)

--- a/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
@@ -68,7 +68,7 @@ namespace MiniExcelLibs.Tests
         {
             [ExcelFormat("yyyy")]
             public DateTime Time { get; set; }
-            
+
             [ExcelColumn(Format = "yyyy")]
             public DateTime Time2 { get; set; }
         }
@@ -229,7 +229,7 @@ namespace MiniExcelLibs.Tests
 
                 {
                     var q = await MiniExcel.QueryAsync<Issue241Dto>(path);
-                    var rows = q.ToList(); 
+                    var rows = q.ToList();
                     Assert.Equal(rows[0].InDate, new DateTime(2021, 01, 04));
                     Assert.Equal(rows[1].InDate, new DateTime(2020, 04, 05));
                 }
@@ -548,14 +548,14 @@ namespace MiniExcelLibs.Tests
                 {
                     var q = await MiniExcel.QueryAsync<UserAccount>(path);
                     var rows = q.ToList();
-                    Assert.Equal(100, rows.Count());
+                    Assert.Equal(100, rows.Count);
 
                     Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                     Assert.Equal("Wade", rows[0].Name);
                     Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                     Assert.Equal(36, rows[0].Age);
                     Assert.False(rows[0].VIP);
-                    Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                    Assert.Equal(5019.12m, rows[0].Points);
                     Assert.Equal(1, rows[0].IgnoredProperty);
                 }
                 {
@@ -563,20 +563,18 @@ namespace MiniExcelLibs.Tests
                     {
                         var q = await stream.QueryAsync<UserAccount>();
                         var rows = q.ToList();
-                        Assert.Equal(100, rows.Count());
+                        Assert.Equal(100, rows.Count);
 
                         Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                         Assert.Equal("Wade", rows[0].Name);
                         Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                         Assert.Equal(36, rows[0].Age);
                         Assert.False(rows[0].VIP);
-                        Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                        Assert.Equal(5019.12m, rows[0].Points);
                         Assert.Equal(1, rows[0].IgnoredProperty);
                     }
                 }
             }
-
-
         }
 
         /// <summary>
@@ -613,7 +611,7 @@ namespace MiniExcelLibs.Tests
             Assert.Equal(typeof(object), columns[0].DataType);
             Assert.Equal(typeof(object), columns[1].DataType);
 
-            Assert.Equal((double)123, dt.Rows[1]["A"]);
+            Assert.Equal(123.0, dt.Rows[1]["A"]);
             Assert.Equal("HelloWorld", dt.Rows[2]["B"]);
         }
 
@@ -698,10 +696,10 @@ namespace MiniExcelLibs.Tests
 
                 var q = await MiniExcel.QueryAsync(path, true);
                 var rows = q.ToList();
-                Assert.Equal((double)1, rows[0].Test1);
-                Assert.Equal((double)2, rows[0].Test2);
-                Assert.Equal((double)3, rows[1].Test1);
-                Assert.Equal((double)4, rows[1].Test2);
+                Assert.Equal(1.0, rows[0].Test1);
+                Assert.Equal(2.0, rows[0].Test2);
+                Assert.Equal(3.0, rows[1].Test1);
+                Assert.Equal(4.0, rows[1].Test2);
             }
         }
 
@@ -721,9 +719,9 @@ namespace MiniExcelLibs.Tests
                 Assert.Equal("Test1", table.Columns[0].ColumnName);
                 Assert.Equal("Test2", table.Columns[1].ColumnName);
                 Assert.Equal("1", table.Rows[0]["Test1"]);
-                Assert.Equal((double)2, table.Rows[0]["Test2"]);
+                Assert.Equal(2.0, table.Rows[0]["Test2"]);
                 Assert.Equal("3", table.Rows[1]["Test1"]);
-                Assert.Equal((double)4, table.Rows[1]["Test2"]);
+                Assert.Equal(4.0, table.Rows[1]["Test2"]);
             }
 
             {
@@ -731,9 +729,9 @@ namespace MiniExcelLibs.Tests
                 Assert.Equal("Test1", dt.Rows[0]["A"]);
                 Assert.Equal("Test2", dt.Rows[0]["B"]);
                 Assert.Equal("1", dt.Rows[1]["A"]);
-                Assert.Equal((double)2, dt.Rows[1]["B"]);
+                Assert.Equal(2.0, dt.Rows[1]["B"]);
                 Assert.Equal("3", dt.Rows[2]["A"]);
-                Assert.Equal((double)4, dt.Rows[2]["B"]);
+                Assert.Equal(4.0, dt.Rows[2]["B"]);
             }
         }
 
@@ -794,7 +792,7 @@ namespace MiniExcelLibs.Tests
         }
 
         /// <summary>
-        /// Optimize stream excel type check 
+        /// Optimize stream excel type check
         /// https://github.com/shps951023/MiniExcel/issues/215
         /// </summary>
         [Fact]
@@ -1292,7 +1290,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 var path = @"../../../../../samples/xlsx/TestIssue142.xlsx";
                 await Assert.ThrowsAsync<ArgumentException>(async () =>
                 {
-                    var q = (await MiniExcel.QueryAsync<Issue142VoOverIndex>(path)).ToList(); 
+                    var q = (await MiniExcel.QueryAsync<Issue142VoOverIndex>(path)).ToList();
                 });
             }
 
@@ -1413,7 +1411,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 {
                     var q = await MiniExcel.QueryAsync(path, sheetName: "Sheet1");
                     var rows = q.ToList();
-                    Assert.Equal(6, rows.Count());
+                    Assert.Equal(6, rows.Count);
                     Assert.Equal("Sheet1", MiniExcel.GetSheetNames(path).First());
                 }
                 using (var p = new ExcelPackage(new FileInfo(path)))
@@ -1427,13 +1425,13 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 {
                     var q = await MiniExcel.QueryAsync<UserAccount>(path, sheetName: "Sheet1");
                     var rows = q.ToList();
-                    Assert.Equal(5, rows.Count());
+                    Assert.Equal(5, rows.Count);
 
                     Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                     Assert.Equal("Wade", rows[0].Name);
                     Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                     Assert.False(rows[0].VIP);
-                    Assert.Equal(decimal.Parse("5019"), rows[0].Points);
+                    Assert.Equal(5019m, rows[0].Points);
                     Assert.Equal(1, rows[0].IgnoredProperty);
                 }
             }
@@ -1491,7 +1489,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 await MiniExcel.SaveAsAsync(path, input);
 
                 var q = await MiniExcel.QueryAsync<Issue149VO>(path);
-                var rows = q.Select(s => (string)s.Test).ToList();
+                var rows = q.Select(s => s.Test).ToList();
                 for (int i = 0; i < chars.Length; i++)
                 {
                     output.WriteLine($"{i} , {chars[i]} , {rows[i]}");
@@ -1516,7 +1514,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
             var path = @"../../../../../samples/xlsx/TestIssue153.xlsx";
             var q = await MiniExcel.QueryAsync(path, true);
             var rows = q.First() as IDictionary<string, object>;
-    
+
             Assert.Equal(new[] { "序号", "代号", "新代号", "名称", "XXX", "部门名称", "单位", "ERP工时   (小时)A", "工时(秒) A/3600", "标准人工工时(秒)", "生产标准机器工时(秒)", "财务、标准机器工时(秒)", "更新日期", "产品机种", "备注", "最近一次修改前的标准工时(秒)", "最近一次修改前的标准机时(秒)", "备注1" }
                 , rows.Keys);
         }
@@ -1543,14 +1541,14 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                     Assert.Equal(" ", row["D"]);
                     Assert.Equal(" ", row["E"]);
                     Assert.Equal(" ", row["F"]);
-                    Assert.Equal(Double.Parse("0"), row["G"]);
+                    Assert.Equal(0.0, row["G"]);
                     Assert.Equal("1為港幣 0為台幣", row["H"]);
                 }
                 {
                     var row = rows[1] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("1"), row["A"]);
+                    Assert.Equal(1.0, row["A"]);
                     Assert.Equal("MTX", row["B"]);
-                    Assert.Equal(double.Parse("10"), row["C"]);
+                    Assert.Equal(10.0, row["C"]);
                     Assert.Null(row["D"]);
                     Assert.Null(row["E"]);
                     Assert.Null(row["F"]);
@@ -1559,7 +1557,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 }
                 {
                     var row = rows[2] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("0.95"), row["A"]);
+                    Assert.Equal(0.95, row["A"]);
                 }
             }
 
@@ -1572,16 +1570,16 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 Assert.Equal(10, rows.Count);
                 {
                     var row = rows[0] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("1"), row["比例"]);
+                    Assert.Equal(1.0, row["比例"]);
                     Assert.Equal("MTX", row["商品"]);
-                    Assert.Equal(double.Parse("10"), row["滿倉口數"]);
+                    Assert.Equal(10.0, row["滿倉口數"]);
                     Assert.Null(row["0"]);
                     Assert.Null(row["1為港幣 0為台幣"]);
                 }
 
                 {
                     var row = rows[1] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("0.95"), row["比例"]);
+                    Assert.Equal(0.95, row["比例"]);
                 }
             }
 

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -852,11 +852,11 @@ namespace MiniExcelLibs.Tests
                     for (int i = 0; i < reader.FieldCount; i++)
                     {
                         var v = reader.GetValue(i);
-                        if (rowIndx == 0 && i == 0) Assert.Equal((double)1, v);
+                        if (rowIndx == 0 && i == 0) Assert.Equal(1.0, v);
                         if (rowIndx == 0 && i == 1) Assert.Equal("Jack", v);
                         if (rowIndx == 0 && i == 2) Assert.Equal(new DateTime(2022, 5, 13), v);
                         if (rowIndx == 0 && i == 3) Assert.Equal(File.ReadAllBytes(PathHelper.GetFile("images/TestIssue327.png")), v);
-                        if (rowIndx == 1 && i == 0) Assert.Equal((double)2, v);
+                        if (rowIndx == 1 && i == 0) Assert.Equal(2.0, v);
                         if (rowIndx == 1 && i == 1) Assert.Equal("Henry", v);
                         if (rowIndx == 1 && i == 2) Assert.Equal(new DateTime(2022, 4, 10), v);
                         if (rowIndx == 1 && i == 3) Assert.Equal(File.ReadAllBytes(PathHelper.GetFile("other/TestIssue327.txt")), v);
@@ -910,7 +910,7 @@ namespace MiniExcelLibs.Tests
                             {
                                 Culture = new CultureInfo("en-US"),
                             };
-                            var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
+                            MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         });
                     }
 
@@ -949,7 +949,7 @@ namespace MiniExcelLibs.Tests
                         };
                         var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         Assert.Equal("2018-12-05 00:00:00", rows[0].createtime.ToString("yyyy-MM-dd HH:mm:ss"));
-                        Assert.Equal("123456789", rows[0].amount.ToString());
+                        Assert.Equal(123456789m, rows[0].amount);
                     }
 
                     {
@@ -959,7 +959,7 @@ namespace MiniExcelLibs.Tests
                         };
                         var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         Assert.Equal("2018-05-12 00:00:00", rows[0].createtime.ToString("yyyy-MM-dd HH:mm:ss"));
-                        Assert.Equal("123456.789", rows[0].amount.ToString());
+                        Assert.Equal(123456.789m, rows[0].amount);
                     }
                 }
             }
@@ -985,7 +985,7 @@ namespace MiniExcelLibs.Tests
                             {
                                 Culture = new CultureInfo("en-US"),
                             };
-                            var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
+                            MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         });
                     }
 
@@ -1024,7 +1024,7 @@ namespace MiniExcelLibs.Tests
                         };
                         var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         Assert.Equal("2018-12-05 00:00:00", rows[0].createtime.ToString("yyyy-MM-dd HH:mm:ss"));
-                        Assert.Equal("123456789", rows[0].amount.ToString());
+                        Assert.Equal(123456789m, rows[0].amount);
                     }
 
                     {
@@ -1034,7 +1034,7 @@ namespace MiniExcelLibs.Tests
                         };
                         var rows = MiniExcel.Query<TestIssue316Dto>(path, configuration: config).ToList();
                         Assert.Equal("2018-05-12 00:00:00", rows[0].createtime.ToString("yyyy-MM-dd HH:mm:ss"));
-                        Assert.Equal("123456.789", rows[0].amount.ToString());
+                        Assert.Equal(123456.789m, rows[0].amount);
                     }
                 }
             }
@@ -2269,7 +2269,7 @@ Henry,44,Jerry,44
                     Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                     Assert.Equal(36, rows[0].Age);
                     Assert.False(rows[0].VIP);
-                    Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                    Assert.Equal(5019.12m, rows[0].Points);
                     Assert.Equal(1, rows[0].IgnoredProperty);
                 }
                 {
@@ -2284,7 +2284,7 @@ Henry,44,Jerry,44
                         Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                         Assert.Equal(36, rows[0].Age);
                         Assert.False(rows[0].VIP);
-                        Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                        Assert.Equal(5019.12m, rows[0].Points);
                         Assert.Equal(1, rows[0].IgnoredProperty);
                     }
                 }
@@ -2327,7 +2327,7 @@ Henry,44,Jerry,44
             Assert.Equal(typeof(object), columns[0].DataType);
             Assert.Equal(typeof(object), columns[1].DataType);
 
-            Assert.Equal((double)123, dt.Rows[1]["A"]);
+            Assert.Equal(123.0, dt.Rows[1]["A"]);
             Assert.Equal("HelloWorld", dt.Rows[2]["B"]);
         }
 
@@ -2410,10 +2410,10 @@ Henry,44,Jerry,44
                 MiniExcel.SaveAs(path, reader);
 
                 var rows = MiniExcel.Query(path, true).ToList();
-                Assert.Equal((double)1, rows[0].Test1);
-                Assert.Equal((double)2, rows[0].Test2);
-                Assert.Equal((double)3, rows[1].Test1);
-                Assert.Equal((double)4, rows[1].Test2);
+                Assert.Equal(1.0, rows[0].Test1);
+                Assert.Equal(2.0, rows[0].Test2);
+                Assert.Equal(3.0, rows[1].Test1);
+                Assert.Equal(4.0, rows[1].Test2);
             }
         }
 
@@ -2432,9 +2432,9 @@ Henry,44,Jerry,44
                 Assert.Equal("Test1", table.Columns[0].ColumnName);
                 Assert.Equal("Test2", table.Columns[1].ColumnName);
                 Assert.Equal("1", table.Rows[0]["Test1"]);
-                Assert.Equal((double)2, table.Rows[0]["Test2"]);
+                Assert.Equal(2.0, table.Rows[0]["Test2"]);
                 Assert.Equal("3", table.Rows[1]["Test1"]);
-                Assert.Equal((double)4, table.Rows[1]["Test2"]);
+                Assert.Equal(4.0, table.Rows[1]["Test2"]);
             }
 
             {
@@ -2442,9 +2442,9 @@ Henry,44,Jerry,44
                 Assert.Equal("Test1", dt.Rows[0]["A"]);
                 Assert.Equal("Test2", dt.Rows[0]["B"]);
                 Assert.Equal("1", dt.Rows[1]["A"]);
-                Assert.Equal((double)2, dt.Rows[1]["B"]);
+                Assert.Equal(2.0, dt.Rows[1]["B"]);
                 Assert.Equal("3", dt.Rows[2]["A"]);
-                Assert.Equal((double)4, dt.Rows[2]["B"]);
+                Assert.Equal(4.0, dt.Rows[2]["B"]);
             }
         }
 
@@ -2503,7 +2503,7 @@ Henry,44,Jerry,44
         }
 
         /// <summary>
-        /// Optimize stream excel type check 
+        /// Optimize stream excel type check
         /// https://github.com/shps951023/MiniExcel/issues/215
         /// </summary>
         [Fact]
@@ -3139,7 +3139,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                     Assert.Equal("Wade", rows[0].Name);
                     Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                     Assert.False(rows[0].VIP);
-                    Assert.Equal(decimal.Parse("5019"), rows[0].Points);
+                    Assert.Equal(5019m, rows[0].Points);
                     Assert.Equal(1, rows[0].IgnoredProperty);
                 }
             }
@@ -3242,14 +3242,14 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                     Assert.Equal(" ", row["D"]);
                     Assert.Equal(" ", row["E"]);
                     Assert.Equal(" ", row["F"]);
-                    Assert.Equal(Double.Parse("0"), row["G"]);
+                    Assert.Equal(0.0, row["G"]);
                     Assert.Equal("1為港幣 0為台幣", row["H"]);
                 }
                 {
                     var row = rows[1] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("1"), row["A"]);
+                    Assert.Equal(1.0, row["A"]);
                     Assert.Equal("MTX", row["B"]);
-                    Assert.Equal(double.Parse("10"), row["C"]);
+                    Assert.Equal(10.0, row["C"]);
                     Assert.Null(row["D"]);
                     Assert.Null(row["E"]);
                     Assert.Null(row["F"]);
@@ -3258,7 +3258,7 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 }
                 {
                     var row = rows[2] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("0.95"), row["A"]);
+                    Assert.Equal(0.95, row["A"]);
                 }
             }
 
@@ -3270,16 +3270,16 @@ MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
                 Assert.Equal(10, rows.Count);
                 {
                     var row = rows[0] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("1"), row["比例"]);
+                    Assert.Equal(1.0, row["比例"]);
                     Assert.Equal("MTX", row["商品"]);
-                    Assert.Equal(double.Parse("10"), row["滿倉口數"]);
+                    Assert.Equal(10.0, row["滿倉口數"]);
                     Assert.Null(row["0"]);
                     Assert.Null(row["1為港幣 0為台幣"]);
                 }
 
                 {
                     var row = rows[1] as IDictionary<string, object>;
-                    Assert.Equal(double.Parse("0.95"), row["比例"]);
+                    Assert.Equal(0.95, row["比例"]);
                 }
             }
 

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -316,7 +316,7 @@ namespace MiniExcelLibs.Tests
         public void TestIssueI4ZYUU()
         {
             var path = PathHelper.GetTempPath();
-            var value = new TestIssueI4ZYUUDto[] { new TestIssueI4ZYUUDto { MyProperty = "1", MyProperty2 = new DateTime(2022, 10, 15) } };
+            var value = new TestIssueI4ZYUUDto[] { new() { MyProperty = "1", MyProperty2 = new DateTime(2022, 10, 15) } };
             MiniExcel.SaveAs(path, value);
             var rows = MiniExcel.Query(path).ToList();
             Assert.Equal("2022-10", rows[1].B);

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -64,7 +64,7 @@ namespace MiniExcelLibs.Tests
             [ExcelColumnIndex(3)] // start with 0
             public string Test7 { get; set; }
         }
-        
+
         public class ExcelAttributeDemo2
         {
             [ExcelColumn(Name = "Column1")]
@@ -89,7 +89,7 @@ namespace MiniExcelLibs.Tests
             {
                 var q = await MiniExcel.QueryAsync<CustomAttributesWihoutVaildPropertiesTestPoco>(path);
                 q.ToList();
-            }); 
+            });
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace MiniExcelLibs.Tests
             Assert.Null(rows[0].Test6);
             Assert.Equal("Test4", rows[0].Test7);
         }
-        
+
         [Fact]
         public async Task QueryCustomAttributes2Test()
         {
@@ -148,7 +148,7 @@ namespace MiniExcelLibs.Tests
                 Assert.Equal(3, rows.Count);
             }
         }
-        
+
         [Fact]
         public async Task SaveAsCustomAttributes2Test()
         {
@@ -336,28 +336,28 @@ namespace MiniExcelLibs.Tests
             {
                 var d = await stream.QueryAsync<UserAccount>();
                 var rows = d.ToList();
-                Assert.Equal(100, rows.Count());
+                Assert.Equal(100, rows.Count);
 
                 Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                 Assert.Equal("Wade", rows[0].Name);
                 Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                 Assert.Equal(36, rows[0].Age);
                 Assert.False(rows[0].VIP);
-                Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                Assert.Equal(5019.12m, rows[0].Points);
                 Assert.Equal(1, rows[0].IgnoredProperty);
             }
 
             {
                 var rows = MiniExcel.Query<UserAccount>(path).ToList();
 
-                Assert.Equal(100, rows.Count());
+                Assert.Equal(100, rows.Count);
 
                 Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                 Assert.Equal("Wade", rows[0].Name);
                 Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                 Assert.Equal(36, rows[0].Age);
                 Assert.False(rows[0].VIP);
-                Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                Assert.Equal(5019.12m, rows[0].Points);
                 Assert.Equal(1, rows[0].IgnoredProperty);
             }
         }

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -27,7 +27,7 @@ namespace MiniExcelLibs.Tests
         {
             this.output = output;
         }
-        
+
         [Fact]
         public void GetColumnsTest()
         {
@@ -300,28 +300,28 @@ namespace MiniExcelLibs.Tests
             {
                 var rows = stream.Query<UserAccount>().ToList();
 
-                Assert.Equal(100, rows.Count());
+                Assert.Equal(100, rows.Count);
 
                 Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                 Assert.Equal("Wade", rows[0].Name);
                 Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                 Assert.Equal(36, rows[0].Age);
                 Assert.False(rows[0].VIP);
-                Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                Assert.Equal(5019.12m, rows[0].Points);
                 Assert.Equal(1, rows[0].IgnoredProperty);
             }
 
             {
                 var rows = MiniExcel.Query<UserAccount>(path).ToList();
 
-                Assert.Equal(100, rows.Count());
+                Assert.Equal(100, rows.Count);
 
                 Assert.Equal(Guid.Parse("78DE23D2-DCB6-BD3D-EC67-C112BBC322A2"), rows[0].ID);
                 Assert.Equal("Wade", rows[0].Name);
                 Assert.Equal(DateTime.ParseExact("27/09/2020", "dd/MM/yyyy", CultureInfo.InvariantCulture), rows[0].BoD);
                 Assert.Equal(36, rows[0].Age);
                 Assert.False(rows[0].VIP);
-                Assert.Equal(decimal.Parse("5019.12"), rows[0].Points);
+                Assert.Equal(5019.12m, rows[0].Points);
                 Assert.Equal(1, rows[0].IgnoredProperty);
             }
         }
@@ -431,8 +431,8 @@ namespace MiniExcelLibs.Tests
                 var rows = stream.Query().ToList();
                 var keys = (rows.First() as IDictionary<string, object>).Keys;
 
-                Assert.Equal(2, rows.Count());
-                Assert.Equal(5, keys.Count());
+                Assert.Equal(2, rows.Count);
+                Assert.Equal(5, keys.Count);
 
                 Assert.Equal(1, rows[0].A);
                 //Assert.Equal(@""" <> +}{/nHello World]", (string)rows[0].B);
@@ -1244,9 +1244,9 @@ namespace MiniExcelLibs.Tests
                 }
             };
             var reader = table.CreateDataReader();
-            
+
             MiniExcel.SaveAs(path, reader, configuration: configuration);
-            
+
             using (var stream = File.OpenRead(path))
             {
                 var rows = stream.Query(useHeaderRow: true)

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -678,7 +678,7 @@ namespace MiniExcelLibs.Tests
                     table.Rows.Add(@"<test>Hello World</test>", -1234567890, false, now.Date);
                 }
 
-                MiniExcel.SaveAs(path, table);
+                MiniExcel.SaveAs(path, table, sheetName: "R&D");
 
                 using (var p = new ExcelPackage(new FileInfo(path)))
                 {
@@ -693,6 +693,8 @@ namespace MiniExcelLibs.Tests
                     Assert.True(ws.Cells["B2"].Value.ToString() == @"1234567890");
                     Assert.True(ws.Cells["C2"].Value.ToString() == true.ToString());
                     Assert.True(ws.Cells["D2"].Value.ToString() == now.ToString());
+
+                    Assert.True(ws.Name == "R&D");
                 }
 
                 File.Delete(path);
@@ -708,6 +710,8 @@ namespace MiniExcelLibs.Tests
                 }
 
                 MiniExcel.SaveAs(path, table);
+
+                File.Delete(path);
             }
         }
 
@@ -760,10 +764,15 @@ namespace MiniExcelLibs.Tests
             {
                 var values = new List<Dictionary<string, object>>()
                 {
-                    new Dictionary<string, object>(){ { "Column1","MiniExcel"},{ "Column2", 1} },
-                     new Dictionary<string, object>(){ { "Column1", "Github" },{ "Column2", 2} },
+                    new() { { "Column1", "MiniExcel" }, { "Column2", 1 } },
+                    new() { { "Column1", "Github" }, { "Column2", 2 } },
                 };
-                MiniExcel.SaveAs(path, values);
+                var sheets = new Dictionary<string, object>
+                {
+                    ["R&D"] = values,
+                    ["success!"] = values
+                };
+                MiniExcel.SaveAs(path, sheets);
 
                 using (var stream = File.OpenRead(path))
                 {
@@ -774,6 +783,8 @@ namespace MiniExcelLibs.Tests
                     Assert.Equal(1, rows[1].B);
                     Assert.Equal("Github", rows[2].A);
                     Assert.Equal(2, rows[2].B);
+
+                    Assert.Equal("R&D", stream.GetSheetNames()[0]);
                 }
 
                 using (var stream = File.OpenRead(path))
@@ -785,6 +796,8 @@ namespace MiniExcelLibs.Tests
                     Assert.Equal(1, rows[0].Column2);
                     Assert.Equal("Github", rows[1].Column1);
                     Assert.Equal(2, rows[1].Column2);
+
+                    Assert.Equal("success!", stream.GetSheetNames()[1]);
                 }
 
                 Assert.Equal("A1:B3", Helpers.GetFirstSheetDimensionRefValue(path));
@@ -794,8 +807,8 @@ namespace MiniExcelLibs.Tests
             {
                 var values = new List<Dictionary<int, object>>()
                 {
-                    new Dictionary<int, object>(){ { 1,"MiniExcel"},{ 2, 1} },
-                     new Dictionary<int, object>(){ { 1, "Github" },{ 2, 2} },
+                    new() { { 1, "MiniExcel"}, { 2, 1 } },
+                    new() { { 1, "Github" }, { 2, 2 } },
                 };
                 MiniExcel.SaveAs(path, values);
 
@@ -1113,7 +1126,7 @@ namespace MiniExcelLibs.Tests
             MiniExcel.SaveAs(path, new[] {
                   new { a = @"""<>+-*//}{\\n", b = 1234567890,c = true,d= now},
                   new { a = "<test>Hello World</test>", b = -1234567890,c=false,d=now.Date}
-             });
+             }, sheetName: "R&D");
             using (var workbook = new XLWorkbook(path))
             {
                 var ws = workbook.Worksheets.First();
@@ -1127,6 +1140,8 @@ namespace MiniExcelLibs.Tests
                 Assert.True(ws.Cell("B2").Value.ToString() == @"1234567890");
                 Assert.True(ws.Cell("C2").Value.ToString() == true.ToString());
                 Assert.True(ws.Cell("D2").Value.ToString() == now.ToString());
+
+                Assert.True(ws.Name == "R&D");
             }
             File.Delete(path);
         }


### PR DESCRIPTION
This pull request addresses three issues:

- It enables the creation of an Excel file with an ampersand in the sheet names by encoding '&' as `&amp;` when writing the XML.
- The unit tests are now functional in environments where the default culture uses a comma as the default decimal separator.
- The column width now consistently uses a dot when serializing the width double.