### PR TITLE
error result when the first row(s) is empty

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -288,11 +288,12 @@ namespace MiniExcelLibs.OpenXml
                                 }
 
                                 // fill empty rows
-                                if (!(nextRowIndex < startRowIndex))
+                                var expectedRowIndex = isFirstRow ? startRowIndex : nextRowIndex;
+                                if (!(expectedRowIndex < startRowIndex))
                                 {
-                                    if (nextRowIndex < rowIndex)
+                                    if (expectedRowIndex < rowIndex)
                                     {
-                                        for (int i = nextRowIndex; i < rowIndex; i++)
+                                        for (int i = expectedRowIndex; i < rowIndex; i++)
                                         {
                                             yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
                                         }


### PR DESCRIPTION
[fix] when first row(s) is empty, query return data will not contain the empty row(s)
![image](https://github.com/mini-software/MiniExcel/assets/21306025/bd50b5b4-2edc-4157-8a15-8c1a4506bcd7)
![image](https://github.com/mini-software/MiniExcel/assets/21306025/715c7fd2-cebb-450f-8ade-4b5fc25a3b4f)

