### PR TITLE
Bugfix/dynamic columns not working

### DIFF
--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -91,7 +91,7 @@
             if (withCustomIndexProps.Any())
                 maxColumnIndex = Math.Max((int)withCustomIndexProps.Max(w => w.ExcelColumnIndex), maxColumnIndex);
 
-            var withoutCustomIndexProps = props.Where(w => w.ExcelColumnIndex == null).ToList();
+            var withoutCustomIndexProps = props.Where(w => w.ExcelColumnIndex == null || w.ExcelColumnIndex == -1).ToList();
 
             List<ExcelColumnInfo> newProps = new List<ExcelColumnInfo>();
             var index = 0;

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -2,6 +2,7 @@
 using Dapper;
 using ExcelDataReader;
 using MiniExcelLibs.Attributes;
+using MiniExcelLibs.OpenXml;
 using MiniExcelLibs.Tests.Utils;
 using OfficeOpenXml;
 using System;
@@ -19,9 +20,6 @@ using static MiniExcelLibs.Tests.Utils.MiniExcelOpenXml;
 
 namespace MiniExcelLibs.Tests
 {
-    using System.Dynamic;
-    using OpenXml;
-
     public partial class MiniExcelOpenXmlAsyncTests
     {
 

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -19,6 +19,9 @@ using static MiniExcelLibs.Tests.Utils.MiniExcelOpenXml;
 
 namespace MiniExcelLibs.Tests
 {
+    using System.Dynamic;
+    using OpenXml;
+
     public partial class MiniExcelOpenXmlAsyncTests
     {
 
@@ -854,6 +857,43 @@ namespace MiniExcelLibs.Tests
                 Assert.Equal("A1:B3", Helpers.GetFirstSheetDimensionRefValue(path));
                 File.Delete(path);
             }
+        }
+
+        [Fact]
+        public async Task SaveAsByIEnumerableIDictionaryWithDynamicConfiguration()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
+            var dynamicColumns = new[]
+            {
+                new DynamicExcelColumn("Column1") { Name = "Name Column" },
+                new DynamicExcelColumn("Column2") { Name = "Value Column" }
+            };
+            var config = new OpenXmlConfiguration
+            {
+                DynamicColumns = dynamicColumns
+            };
+            var values = new List<Dictionary<string, object>>()
+            {
+                new Dictionary<string, object>() { { "Column1", "MiniExcel" }, { "Column2", 1 } },
+                new Dictionary<string, object>() { { "Column1", "Github" }, { "Column2", 2 } },
+            };
+            await MiniExcel.SaveAsAsync(path, values, configuration: config);
+
+            using (var stream = File.OpenRead(path))
+            {
+                var d = (await stream.QueryAsync(useHeaderRow: true)).Cast<IDictionary<string, object>>();
+                var rows = d.ToList();
+                Assert.Equal(2, rows.Count);
+                Assert.Equal("Name Column", rows[0].Keys.ElementAt(0));
+                Assert.Equal("Value Column", rows[0].Keys.ElementAt(1));
+                Assert.Equal("MiniExcel", rows[0].Values.ElementAt(0));
+                Assert.Equal(1d, rows[0].Values.ElementAt(1));
+                Assert.Equal("Github", rows[1].Values.ElementAt(0));
+                Assert.Equal(2d, rows[1].Values.ElementAt(1));
+            }
+
+            Assert.Equal("A1:B3", Helpers.GetFirstSheetDimensionRefValue(path));
+            File.Delete(path);
         }
 
         [Fact()]


### PR DESCRIPTION
If you use `IDictionary` to save a `ExcelOpenXmlSheet` in combination with the DynamicExcelColumns will result in an empty work sheet. 

The problem is that the `ExcelColumnAttribute.Index` is initilized with `-1` but the `SortCustomProps` of the `ExcelColumnInfo` class dose only check if the property is `null`

Also added a unit test for this scenario.

Fixes issue: #445