### PR TITLE
NET Core不落地导出Excel支持

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1528,7 +1528,7 @@ namespace WebApplication1.Controllers
 {
     [ApiController]
     [Route("[controller]")]
-    public class WeatherForecastController : ControllerBase
+    public class StreamDownloadExcelController : ControllerBase
     {
         private static readonly string[] Summaries = new[]
         {

--- a/src/MiniExcel/IConfiguration.cs
+++ b/src/MiniExcel/IConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using MiniExcelLibs.Attributes;
+using System;
 using System.Globalization;
 
 namespace MiniExcelLibs
@@ -9,6 +10,7 @@ namespace MiniExcelLibs
         public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
         public DynamicExcelColumn[] DynamicColumns { get; set; }
         public int BufferSize { get; set; } = 1024 * 512;
+        [Obsolete]
         public bool FastMode { get; set; } = false;
     }
 }

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefualtOpenXml.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefualtOpenXml.cs
@@ -4,7 +4,7 @@ using System.IO.Compression;
 
 namespace MiniExcelLibs.OpenXml
 {
-    internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
+    partial class ExcelOpenXmlSheetWriter : IExcelWriter
     {
         private readonly Dictionary<string, ZipPackageInfo> _zipDictionary = new Dictionary<string, ZipPackageInfo>();
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -38,7 +38,7 @@ namespace MiniExcelLibs.OpenXml
     {
         public string ID { get; set; } = $"R{Guid.NewGuid():N}";
     }
-    internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
+    public partial class ExcelOpenXmlSheetWriter : IExcelWriter
     {
         private readonly MiniExcelZipArchive _archive;
         private readonly static UTF8Encoding _utf8WithBom = new System.Text.UTF8Encoding(true);
@@ -56,10 +56,7 @@ namespace MiniExcelLibs.OpenXml
             // Why ZipArchiveMode.Update not ZipArchiveMode.Create?
             // R : Mode create - ZipArchiveEntry does not support seeking.'
             this._configuration = configuration as OpenXmlConfiguration ?? OpenXmlConfiguration.DefaultConfig;
-            if (_configuration.FastMode)
-                this._archive = new MiniExcelZipArchive(_stream, ZipArchiveMode.Update, true, _utf8WithBom);
-            else
-                this._archive = new MiniExcelZipArchive(_stream, ZipArchiveMode.Create, true, _utf8WithBom);
+            this._archive = new MiniExcelZipArchive(_stream, ZipArchiveMode.Create, true, _utf8WithBom);
             this._printHeader = printHeader;
             this._value = value;
             var defaultSheetInfo = GetSheetInfos(sheetName);
@@ -127,21 +124,8 @@ namespace MiniExcelLibs.OpenXml
             List<ExcelColumnInfo> props = null;
             string mode = null;
 
-            int? rowCount = null;
-            var collection = values as ICollection;
-            if (collection != null)
-            {
-                rowCount = collection.Count;
-            }
-            else if (!_configuration.FastMode)
-            {
-                // The row count is only required up front when not in fastmode
-                collection = new List<object>(values.Cast<object>());
-                rowCount = collection.Count;
-            }
-
             // Get the enumerator once to ensure deferred linq execution
-            var enumerator = (collection ?? values).GetEnumerator();
+            var enumerator = values.GetEnumerator();
 
             // Move to the first item in order to inspect the value type and determine whether it is empty
             var empty = !enumerator.MoveNext();
@@ -186,18 +170,10 @@ namespace MiniExcelLibs.OpenXml
 
             writer.Write($@"<?xml version=""1.0"" encoding=""utf-8""?><x:worksheet xmlns:r=""http://schemas.openxmlformats.org/officeDocument/2006/relationships"" xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"" >");
 
-            long dimensionWritePosition = 0;
-
-            // We can write the dimensions directly if the row count is known
-            if (_configuration.FastMode && rowCount == null)
+            if(values is ICollection collection)
             {
-                // Write a placeholder for the table dimensions and save thee position for later
-                dimensionWritePosition = writer.WriteAndFlush("<x:dimension ref=\"");
-                writer.Write("                              />");
-            }
-            else
-            {
-                maxRowIndex = rowCount.Value + (_printHeader && rowCount > 0 ? 1 : 0);
+                var rowCount = collection.Count;
+                maxRowIndex = rowCount + (_printHeader && rowCount > 0 ? 1 : 0);
                 writer.Write($@"<x:dimension ref=""{GetDimensionRef(maxRowIndex, maxColumnIndex)}""/>");
             }
 
@@ -230,18 +206,6 @@ namespace MiniExcelLibs.OpenXml
             writer.Write("</x:sheetData>");
             if (_configuration.AutoFilter)
                 writer.Write($"<x:autoFilter ref=\"{GetDimensionRef(maxRowIndex, maxColumnIndex)}\" />");
-
-            // The dimension has already been written if row count is defined
-            if (_configuration.FastMode && rowCount == null)
-            {
-                // Flush and save position so that we can get back again.
-                var pos = writer.Flush();
-
-                // Seek back and write the dimensions of the table
-                writer.SetPosition(dimensionWritePosition);
-                writer.WriteAndFlush($@"{GetDimensionRef(maxRowIndex, maxColumnIndex)}""");
-                writer.SetPosition(pos);
-            }
 
             writer.Write("<x:drawing  r:id=\"drawing" + currentSheetIndex + "\" /></x:worksheet>");
         }
@@ -667,20 +631,12 @@ namespace MiniExcelLibs.OpenXml
 
         private void GenerateSheetByIDataReader(MiniExcelStreamWriter writer, IDataReader reader)
         {
-            long dimensionWritePosition = 0;
             writer.Write($@"<?xml version=""1.0"" encoding=""utf-8""?><x:worksheet xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">");
             var xIndex = 1;
             var yIndex = 1;
             var maxColumnIndex = 0;
             var maxRowIndex = 0;
             {
-
-                if (_configuration.FastMode)
-                {
-                    dimensionWritePosition = writer.WriteAndFlush($@"<x:dimension ref=""");
-                    writer.Write("                              />"); // end of code will be replaced
-                }
-
                 var props = new List<ExcelColumnInfo>();
                 for (var i = 0; i < reader.FieldCount; i++)
                 {
@@ -721,12 +677,6 @@ namespace MiniExcelLibs.OpenXml
             if (_configuration.AutoFilter)
                 writer.Write($"<x:autoFilter ref=\"{GetDimensionRef(maxRowIndex, maxColumnIndex)}\" />");
             writer.WriteAndFlush("</x:worksheet>");
-
-            if (_configuration.FastMode)
-            {
-                writer.SetPosition(dimensionWritePosition);
-                writer.WriteAndFlush($@"{GetDimensionRef(maxRowIndex, maxColumnIndex)}""");
-            }
         }
 
         private ExcelColumnInfo GetColumnInfosFromDynamicConfiguration(string columnName)

--- a/src/MiniExcel/OpenXml/MiniExcelAsyncStreamWriter.cs
+++ b/src/MiniExcel/OpenXml/MiniExcelAsyncStreamWriter.cs
@@ -24,6 +24,8 @@ namespace MiniExcelLibs.OpenXml
             this._cancellationToken = cancellationToken;
             this._streamWriter = new StreamWriter(stream, this._encoding, bufferSize);
         }
+
+        private int writeTimes = 0;
         public async Task WriteAsync(string content)
         {
             this._cancellationToken.ThrowIfCancellationRequested();
@@ -31,6 +33,7 @@ namespace MiniExcelLibs.OpenXml
             if (string.IsNullOrEmpty(content))
                 return;
             await this._streamWriter.WriteAsync(content);
+            if (++writeTimes % 1000 == 0) await this.FlushAsync();
         }
 
         public async Task<long> WriteAndFlushAsync(string content)
@@ -45,11 +48,6 @@ namespace MiniExcelLibs.OpenXml
 
             await this._streamWriter.FlushAsync();
             return this._streamWriter.BaseStream.Position;
-        }
-
-        public void SetPosition(long position)
-        {
-            this._streamWriter.BaseStream.Position = position;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/MiniExcel/OpenXml/MiniExcelStreamWriter.cs
+++ b/src/MiniExcel/OpenXml/MiniExcelStreamWriter.cs
@@ -16,11 +16,13 @@ namespace MiniExcelLibs.OpenXml
             this._encoding = encoding;
             this._streamWriter = new StreamWriter(stream, this._encoding, bufferSize);
         }
+        private int writeTimes = 0;
         public void Write(string content)
         {
             if (string.IsNullOrEmpty(content))
                 return;
             this._streamWriter.Write(content);
+            if (++writeTimes % 1000 == 0) this.Flush();
         }
 
         public long WriteAndFlush(string content)
@@ -34,11 +36,6 @@ namespace MiniExcelLibs.OpenXml
         {
             this._streamWriter.Flush();
             return this._streamWriter.BaseStream.Position;
-        }
-
-        public void SetPosition(long position)
-        {
-            this._streamWriter.BaseStream.Position = position;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/MiniExcel/Utils/ImageHelper.cs
+++ b/src/MiniExcel/Utils/ImageHelper.cs
@@ -48,7 +48,7 @@
         }
 #endif
 
-#if  NET5_0
+#if  NET5_0_OR_GREATER
         public static ImageFormat GetImageFormat(ReadOnlySpan<byte> bytes)
         {
             ReadOnlySpan<byte> bmp = stackalloc byte[] { (byte)'B', (byte)'M' };            // BMP


### PR DESCRIPTION
1.废除FastMode, 支持http响应流直接输出(取消了流回退功能,见解释)
2.每1000行进行重刷一次,节约内存
3不使用new List导致迭代器全部计算浪费内存
4.解释:
在OpenXML中，<x:dimension ref="..."/> 元素指定了工作表中使用的单元格区域，它定义了工作表中所有单元格的最小矩形范围。这个元素是可选的，因为Excel和其他兼容的电子表格程序通常能够在没有这个元素的情况下打开文件，并计算出实际使用的单元格范围。

然而，省略 <x:dimension ref="..."/> 可能会导致性能问题，尤其是在处理大型工作表时。如果存在这个元素，电子表格程序可以直接定位到工作表中的活动区域，而不需要扫描整个工作表来确定哪些单元格包含数据。这可以减少文件打开的时间和内存使用量。

所以，如果你在乎打开文件的性能，特别是对于大型的工作表，最好是包含 <x:dimension ref="..."/> 元素。但如果你在生成的文件中遇到兼容性问题，或者你正在处理的是小型工作表，并且不太关心打开文件的性能，那么你可以选择省略它。

在OpenXML SDK中，如果你使用OpenXmlWriter来写入工作表，你可以选择是否写入这个元素。如果你决定省略它，确保你的电子表格程序能够在没有这个元素的情况下正确处理文件。