### PR TITLE
bug: Cannot do this for multiple selection

### DIFF
--- a/src/MiniExcel/OpenXml/Constants/WorksheetXml.cs
+++ b/src/MiniExcel/OpenXml/Constants/WorksheetXml.cs
@@ -16,7 +16,7 @@ namespace MiniExcelLibs.OpenXml.Constants
         internal const string StartSheetViews = "<x:sheetViews>";
         internal const string EndSheetViews = "</x:sheetViews>";
 
-        internal static string StartSheetView( int tabSelected=1, int workbookViewId=0 )
+        internal static string StartSheetView( int tabSelected=0, int workbookViewId=0 )
             => $"<x:sheetView tabSelected=\"{tabSelected}\" workbookViewId=\"{workbookViewId}\">";
         internal const string EndSheetView = "</x:sheetView>";
 


### PR DESCRIPTION
When tabSelected="1", the resulting Excel will say "Cannot do this for multiple selected areas"
![image](https://github.com/user-attachments/assets/e2f1e76a-8601-499a-acd8-c8118ec0083a)
