### PR TITLE
Fix QueryAsDataTable can't read Excel with only header rows

### DIFF
--- a/src/MiniExcel/MiniExcel.cs
+++ b/src/MiniExcel/MiniExcel.cs
@@ -193,12 +193,12 @@
                 {
                     foreach (var entry in row)
                     {
-                        var columnName = useHeaderRow ? entry.Value.ToString() : entry.Key;
-                        if (!string.IsNullOrEmpty(columnName)) // avoid #298 : Column '' does not belong to table
+                        var columnName = useHeaderRow ? entry.Value?.ToString() : entry.Key;
+                        if (!string.IsNullOrWhiteSpace(columnName)) // avoid #298 : Column '' does not belong to table
                         {
                             var column = new DataColumn(columnName, typeof(object)) { Caption = columnName };
                             dt.Columns.Add(column);
-                            columnDict.Add(entry.Key, columnName);
+                            columnDict.Add(entry.Key, columnName);//same column name throw exception???
                         }
                     }
                     dt.BeginLoadData();

--- a/src/MiniExcel/MiniExcel.cs
+++ b/src/MiniExcel/MiniExcel.cs
@@ -184,31 +184,35 @@
 
             var dt = new DataTable(sheetName);
             var first = true;
-            var rows = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration).Query(useHeaderRow, sheetName, startCell);
+            var rows = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration).Query(false, sheetName, startCell);
 
-            var keys = new List<string>();
+            var columnDict = new Dictionary<string, string>();
             foreach (IDictionary<string, object> row in rows)
             {
                 if (first)
                 {
-                    foreach (var key in row.Keys)
+                    foreach (var entry in row)
                     {
-                        if (!string.IsNullOrEmpty(key)) // avoid #298 : Column '' does not belong to table
+                        var columnName = useHeaderRow ? entry.Value.ToString() : entry.Key;
+                        if (!string.IsNullOrEmpty(columnName)) // avoid #298 : Column '' does not belong to table
                         {
-                            var column = new DataColumn(key, typeof(object)) { Caption = key };
+                            var column = new DataColumn(columnName, typeof(object)) { Caption = columnName };
                             dt.Columns.Add(column);
-                            keys.Add(key);
+                            columnDict.Add(entry.Key, columnName);
                         }
                     }
-
                     dt.BeginLoadData();
                     first = false;
+                    if (useHeaderRow)
+                    {
+                        continue;
+                    }
                 }
 
                 var newRow = dt.NewRow();
-                foreach (var key in keys)
+                foreach (var entry in columnDict)
                 {
-                    newRow[key] = row[key]; //TODO: optimize not using string key
+                    newRow[entry.Value] = row[entry.Key]; //TODO: optimize not using string key
                 }
 
                 dt.Rows.Add(newRow);


### PR DESCRIPTION
QueryAsDataTable不推荐使用，但是有些特殊情况下还是很好用的，目前发现如果Excel只有一个表头行时，无法正确读取，读取到的DataTable会没有任何列，这个PR修复了此问题