### PR TITLE
Fix - Missing leading zeros

### DIFF
--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -1142,7 +1142,7 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
                         else
                         {
                             var cellValueStr = cellValue?.ToString(); /* value did encodexml, so don't duplicate encode value https://gitee.com/dotnetchina/MiniExcel/issues/I4DQUN*/
-                            if (isMultiMatch) // if matchs count over 1 need to set type=str ![image](https://user-images.githubusercontent.com/12729184/114530109-39d46d00-9c7d-11eb-8f6b-52ad8600aca3.png)
+                            if (isMultiMatch || cellValue is string) // if matchs count over 1 need to set type=str ![image](https://user-images.githubusercontent.com/12729184/114530109-39d46d00-9c7d-11eb-8f6b-52ad8600aca3.png)
                             {
                                 c.SetAttribute("t", "str");
                             }


### PR DESCRIPTION
If cellValue is string no matter that it contains only numbers will put the value as text. Preventing of losing leading zeroes
#696 