### PR TITLE
feat: Enhance IDataReader export with DynamicColumnFirst and Custom Formatting Delegate

### DIFF
--- a/src/MiniExcel/Attributes/ExcelColumnAttribute.cs
+++ b/src/MiniExcel/Attributes/ExcelColumnAttribute.cs
@@ -57,6 +57,8 @@ namespace MiniExcelLibs.Attributes
     public class DynamicExcelColumn : ExcelColumnAttribute
     {
         public string Key { get; set; }
+        
+        public Func<object, string> CustomFormatter { get; set; }
 
         public DynamicExcelColumn(string key)
         {

--- a/src/MiniExcel/IConfiguration.cs
+++ b/src/MiniExcel/IConfiguration.cs
@@ -10,5 +10,10 @@ namespace MiniExcelLibs
         public DynamicExcelColumn[] DynamicColumns { get; set; }
         public int BufferSize { get; set; } = 1024 * 512;
         public bool FastMode { get; set; } = false;
+        
+        /// <summary>
+        ///     When exporting using DataReader, the data not in DynamicColumn will be filtered.
+        /// </summary>
+        public bool DynamicColumnFirst { get; set; } = false;
     }
 }

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
@@ -192,7 +192,7 @@ namespace MiniExcelLibs.OpenXml
             if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0)
                 return prop;
 
-            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => _.Key == columnName);
+            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => string.Equals(_.Key , columnName,StringComparison.OrdinalIgnoreCase));
             if (dynamicColumn == null || dynamicColumn.Ignore)
             {
                 return prop;
@@ -203,6 +203,7 @@ namespace MiniExcelLibs.OpenXml
             prop.ExcelColumnType = dynamicColumn.Type;
             prop.ExcelColumnIndex = dynamicColumn.Index;
             prop.ExcelColumnWidth = dynamicColumn.Width;
+            prop.CustomFormatter = dynamicColumn.CustomFormatter;
             //prop.ExcludeNullableType = item2[key]?.GetType();
 
             if (dynamicColumn.Format != null)

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -570,6 +570,19 @@ namespace MiniExcelLibs.OpenXml
             var styleIndex = tuple.Item1; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-3.0.1
             var dataType = tuple.Item2; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cellvalues?view=openxml-3.0.1
             var cellValue = tuple.Item3;
+            
+            if (columnInfo?.CustomFormatter != null)
+            {
+                try
+                {
+                    cellValue = columnInfo.CustomFormatter(cellValue);
+                }
+                catch (Exception e)
+                {
+                    //ignored
+                }
+            }
+            
             var columnType = columnInfo?.ExcelColumnType ?? ColumnType.Value;
 
             /*Prefix and suffix blank space will lost after SaveAs #294*/

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -25,6 +25,7 @@
         public bool ExcelIgnore { get; internal set; }
         public int ExcelFormatId { get; internal set; }
         public ColumnType ExcelColumnType { get; internal set; }
+        public Func<object, string> CustomFormatter { get; set; }
     }
 
     internal class ExcellSheetInfo
@@ -310,6 +311,7 @@
                     isIgnore = dynamicColumn.Ignore;
                     p.ExcelColumnWidth = dynamicColumn.Width;
                     p.ExcelColumnType = dynamicColumn.Type;
+                    p.CustomFormatter = dynamicColumn.CustomFormatter;
                 }
             }
             if (!isIgnore)


### PR DESCRIPTION
When exporting using `IDataReader`, I noticed that even when passing `DynamicColumn`, the exported content was not being exported according to the passed data.

In this PR, the following adjustments have been made for exporting using `IDataReader`:
- Added the `DynamicColumnFirst` property to the configuration, which ensures that the data in `DynamicColumn` is used as the standard for exporting (currently only handled for `IDataReader`). To avoid breaking changes and unexpected behavior, this configuration item is added with a default value of `false`.
- Added a custom data formatting delegate in `ExcelColumnInfo` and `DynamicColumn`.
- Adjusted the method `GetColumnInfosFromDynamicConfiguration` to filter `DynamicColumn` in a case-insensitive manner.

When exporting data, some data is not directly obtained from the database. Therefore, a custom formatting delegate method has been added to format the data.