### PR TITLE
feat: support insert sheet

### DIFF
--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -64,6 +64,21 @@ namespace MiniExcelLibs.Csv
             }
         }
 
+        public async Task SaveAsAsync(CancellationToken cancellationToken = default)
+        {
+            await Task.Run(() => SaveAs(), cancellationToken).ConfigureAwait(false);
+        }
+
+        public void Insert(bool overwriteSheet = false)
+        {
+            SaveAs();
+        }
+
+        public async Task InsertAsync(bool overwriteSheet = false, CancellationToken cancellationToken = default)
+        {
+            await Task.Run(() => SaveAs(), cancellationToken).ConfigureAwait(false);
+        }
+
         private void GenerateSheetByIEnumerable(IEnumerable values, string seperator, string newLine, StreamWriter writer)
         {
             Type genericType = null;
@@ -128,16 +143,6 @@ namespace MiniExcelLibs.Csv
                 else
                     throw new NotImplementedException($"Mode for genericType {genericType?.Name} not Implemented. please issue for me.");
             }
-        }
-
-        public void Insert()
-        {
-            SaveAs();
-        }
-
-        public async Task SaveAsAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            await Task.Run(() => SaveAs(), cancellationToken).ConfigureAwait(false);
         }
 
         private void GenerateSheetByIDataReader(IDataReader reader, string seperator, string newLine, StreamWriter writer)

--- a/src/MiniExcel/IExcelWriter.cs
+++ b/src/MiniExcel/IExcelWriter.cs
@@ -6,7 +6,8 @@ namespace MiniExcelLibs
     internal interface IExcelWriter
     {
         void SaveAs();
-        Task SaveAsAsync(CancellationToken cancellationToken = default(CancellationToken));
-        void Insert();
+        Task SaveAsAsync(CancellationToken cancellationToken = default);
+        void Insert(bool overwriteSheet = false);
+        Task InsertAsync(bool overwriteSheet = false, CancellationToken cancellationToken = default);
     }
 }

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
@@ -16,12 +16,8 @@ namespace MiniExcelLibs.OpenXml
 {
     internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
     {
-        public void Insert()
-        {
-            throw new NotImplementedException();
-        }
-
         private readonly Dictionary<string, ZipPackageInfo> _zipDictionary = new Dictionary<string, ZipPackageInfo>();
+        private Dictionary<string, string> cellXfIdMap;
 
         private IEnumerable<Tuple<SheetDto, object>> GetSheets()
         {
@@ -83,7 +79,7 @@ namespace MiniExcelLibs.OpenXml
 
             return info;
         }
-        
+
         private string GetSheetViews()
         {
             // exit early if no style to write
@@ -192,7 +188,7 @@ namespace MiniExcelLibs.OpenXml
             if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0)
                 return prop;
 
-            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => string.Equals(_.Key , columnName,StringComparison.OrdinalIgnoreCase));
+            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => string.Equals(_.Key, columnName, StringComparison.OrdinalIgnoreCase));
             if (dynamicColumn == null || dynamicColumn.Ignore)
             {
                 return prop;
@@ -237,7 +233,7 @@ namespace MiniExcelLibs.OpenXml
             {
                 throw new NotImplementedException($"MiniExcel not support only {genericType.Name} value generic type");
             }
-            
+
             if (genericType == typeof(string) || genericType == typeof(DateTime) || genericType == typeof(Guid))
             {
                 throw new NotImplementedException($"MiniExcel not support only {genericType.Name} generic type");
@@ -261,7 +257,7 @@ namespace MiniExcelLibs.OpenXml
             }
 
             var type = GetValueType(value, columnInfo);
-            
+
 
             if (columnInfo?.ExcelFormat != null && columnInfo?.ExcelFormatId == -1 && value is IFormattable formattableValue)
             {
@@ -285,7 +281,7 @@ namespace MiniExcelLibs.OpenXml
                 var description = CustomPropertyHelper.DescriptionAttr(type, value);
                 return Tuple.Create("2", "str", description ?? value.ToString());
             }
-            
+
             if (TypeHelper.IsNumericType(type))
             {
                 var dataType = _configuration.Culture == CultureInfo.InvariantCulture ? "n" : "str";
@@ -295,7 +291,7 @@ namespace MiniExcelLibs.OpenXml
 
                 return Tuple.Create("2", dataType, cellValue);
             }
-            
+
             if (type == typeof(bool))
             {
                 return Tuple.Create("2", "b", (bool)value ? "1" : "0");
@@ -334,42 +330,42 @@ namespace MiniExcelLibs.OpenXml
             {
                 return ((decimal)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(int)))
             {
                 return ((int)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(double)))
             {
                 return ((double)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(long)))
             {
                 return ((long)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(uint)))
             {
                 return ((uint)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(ushort)))
             {
                 return ((ushort)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(ulong)))
             {
                 return ((ulong)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(short)))
             {
                 return ((short)value).ToString(_configuration.Culture);
             }
-            
+
             if (type.IsAssignableFrom(typeof(float)))
             {
                 return ((float)value).ToString(_configuration.Culture);
@@ -459,19 +455,6 @@ namespace MiniExcelLibs.OpenXml
             return dimensionRef;
         }
 
-        private string GetStylesXml(ICollection<ExcelColumnAttribute> columns)
-        {
-            switch (_configuration.TableStyles)
-            {
-                case TableStyles.None:
-                    return new MinimalSheetStyleBuilder().Build( columns);
-                case TableStyles.Default:
-                    return new DefaultSheetStyleBuilder().Build( columns );
-                default:
-                    return string.Empty;
-            }
-        }
-
         private string GetDrawingRelationshipXml(int sheetIndex)
         {
             var drawing = new StringBuilder();
@@ -488,7 +471,7 @@ namespace MiniExcelLibs.OpenXml
             var drawing = new StringBuilder();
 
             for (int fileIndex = 0; fileIndex < _files.Count; fileIndex++)
-            { 
+            {
                 var file = _files[fileIndex];
                 if (file.IsImage && file.SheetId == sheetIndex + 1)
                 {
@@ -531,6 +514,15 @@ namespace MiniExcelLibs.OpenXml
 
             sb.Append(ExcelXml.EndTypes);
             return sb.ToString();
+        }
+
+        private string GetCellXfId(string styleIndex)
+        {
+            if (cellXfIdMap.TryGetValue(styleIndex, out var cellXfId))
+            {
+                return cellXfId.ToString();
+            }
+            return styleIndex.ToString();
         }
     }
 }

--- a/src/MiniExcel/OpenXml/Styles/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel/OpenXml/Styles/DefaultSheetStyleBuilder.cs
@@ -1,156 +1,956 @@
-﻿using MiniExcelLibs.Attributes;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Threading.Tasks;
 
-namespace MiniExcelLibs.OpenXml.Styles {
-
-    public class DefaultSheetStyleBuilder : ISheetStyleBuilder
+namespace MiniExcelLibs.OpenXml.Styles
+{
+    internal class DefaultSheetStyleBuilder : SheetStyleBuilderBase
     {
-        private const int startUpNumFmts = 1;
-        private const string NumFmtsToken = "{{numFmts}}";
-        private const string NumFmtsCountToken = "{{numFmtCount}}";
+        internal static SheetStyleElementInfos GenerateElementInfos = new SheetStyleElementInfos
+        {
+            NumFmtCount = 0,//默认的NumFmt数量是0，但是会有根据ColumnsToApply动态生成的NumFmt
+            FontCount = 2,
+            FillCount = 3,
+            BorderCount = 2,
+            CellStyleXfCount = 3,
+            CellXfCount = 5
+        };
 
-        private const int startUpCellXfs = 5;
-        private const string cellXfsToken = "{{cellXfs}}";
-        private const string cellXfsCountToken = "{{cellXfsCount}}";
+        private readonly SheetStyleBuildContext _context;
 
-        internal static readonly string DefaultStylesXml = ExcelOpenXmlUtils.MinifyXml
-        ( $@"
-            <?xml version=""1.0"" encoding=""utf-8""?>
-            <x:styleSheet xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">
-                <x:numFmts count=""{NumFmtsCountToken}"">
-                    <x:numFmt numFmtId=""0"" formatCode="""" />
-                    {NumFmtsToken}
-                </x:numFmts>
-                <x:fonts count=""2"">
-                    <x:font>
-                        <x:vertAlign val=""baseline"" />
-                        <x:sz val=""11"" />
-                        <x:color rgb=""FF000000"" />
-                        <x:name val=""Calibri"" />
-                        <x:family val=""2"" />
-                    </x:font>
-                    <x:font>
-                        <x:vertAlign val=""baseline"" />
-                        <x:sz val=""11"" />
-                        <x:color rgb=""FFFFFFFF"" />
-                        <x:name val=""Calibri"" />
-                        <x:family val=""2"" />
-                    </x:font>
-                </x:fonts>
-                <x:fills count=""3"">
-                    <x:fill>
-                        <x:patternFill patternType=""none"" />
-                    </x:fill>
-                    <x:fill>
-                        <x:patternFill patternType=""gray125"" />
-                    </x:fill>
-                    <x:fill>
-                        <x:patternFill patternType=""solid"">
-                            <x:fgColor rgb=""284472C4"" />
-                        </x:patternFill>
-                    </x:fill>
-                </x:fills>
-                <x:borders count=""2"">
-                    <x:border diagonalUp=""0"" diagonalDown=""0"">
-                        <x:left style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:left>
-                        <x:right style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:right>
-                        <x:top style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:top>
-                        <x:bottom style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:bottom>
-                        <x:diagonal style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:diagonal>
-                    </x:border>
-                    <x:border diagonalUp=""0"" diagonalDown=""0"">
-                        <x:left style=""thin"">
-                            <x:color rgb=""FF000000"" />
-                        </x:left>
-                        <x:right style=""thin"">
-                            <x:color rgb=""FF000000"" />
-                        </x:right>
-                        <x:top style=""thin"">
-                            <x:color rgb=""FF000000"" />
-                        </x:top>
-                        <x:bottom style=""thin"">
-                            <x:color rgb=""FF000000"" />
-                        </x:bottom>
-                        <x:diagonal style=""none"">
-                            <x:color rgb=""FF000000"" />
-                        </x:diagonal>
-                    </x:border>
-                </x:borders>
-                <x:cellStyleXfs count=""3"">
-                    <x:xf numFmtId=""0"" fontId=""0"" fillId=""0"" borderId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""0"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                    <x:xf numFmtId=""14"" fontId=""1"" fillId=""2"" borderId=""1"" applyNumberFormat=""1"" applyFill=""0"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                    <x:xf numFmtId=""0"" fontId=""0"" fillId=""0"" borderId=""1"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                </x:cellStyleXfs>
-                <x:cellXfs count=""{cellXfsCountToken}"">
-                    <x:xf></x:xf>
-                    <x:xf numFmtId=""0"" fontId=""1"" fillId=""2"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""0"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:alignment horizontal=""left"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                    <x:xf numFmtId=""0"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:alignment horizontal=""general"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                    <x:xf numFmtId=""14"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-                        <x:alignment horizontal=""general"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
-                        <x:protection locked=""1"" hidden=""0"" />
-                    </x:xf>
-                    <x:xf numFmtId=""0"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyBorder=""1"" applyAlignment=""1"">
-                        <x:alignment horizontal=""fill""/>
-                    </x:xf>
-                    {cellXfsToken}
-                </x:cellXfs>
-                <x:cellStyles count=""1"">
-                    <x:cellStyle name=""Normal"" xfId=""0"" builtinId=""0"" />
-                </x:cellStyles>
-            </x:styleSheet>"
-        );
+        public DefaultSheetStyleBuilder(SheetStyleBuildContext context) : base(context)
+        {
+            _context = context;
+        }
 
-        public string Build( ICollection<ExcelColumnAttribute> columns )
+        protected override SheetStyleElementInfos GetGenerateElementInfos()
+        {
+            return GenerateElementInfos;
+        }
+
+        protected override void GenerateNumFmt()
         {
             const int numFmtIndex = 166;
 
-            var sb = new StringBuilder( DefaultStylesXml );
-            var columnsToApply = SheetStyleBuilderHelper.GenerateStyleIds( startUpCellXfs, columns );
-
-            var numFmts = columnsToApply.Select( ( x, i ) =>
+            var index = 0;
+            foreach (var item in _context.ColumnsToApply)
             {
-                return new
-                {
-                    numFmt = $@"<x:numFmt numFmtId=""{numFmtIndex + i}"" formatCode=""{x.Format}"" />",
+                index++;
 
-                    cellXfs = $@"<x:xf numFmtId=""{numFmtIndex + i}"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
-    <x:alignment horizontal=""general"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
-    <x:protection locked=""1"" hidden=""0"" />
-</x:xf>"
-                };
-            } ).ToArray();
+                /*
+                 * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{x.Format}"
+                 */
+                _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "numFmt", _context.OldXmlReader.NamespaceURI);
+                _context.NewXmlWriter.WriteAttributeString("numFmtId", (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                _context.NewXmlWriter.WriteAttributeString("formatCode", item.Format);
+                _context.NewXmlWriter.WriteFullEndElement();
+            }
+        }
 
-            sb.Replace( NumFmtsToken, string.Join( string.Empty, numFmts.Select( x => x.numFmt ) ) );
-            sb.Replace( NumFmtsCountToken, (startUpNumFmts + numFmts.Length).ToString() );
+        protected override async Task GenerateNumFmtAsync()
+        {
+            const int numFmtIndex = 166;
+            var index = 0;
+            foreach (var item in _context.ColumnsToApply)
+            {
+                index++;
 
-            sb.Replace( cellXfsToken, string.Join( string.Empty, numFmts.Select( x => x.cellXfs ) ) );
-            sb.Replace( cellXfsCountToken, (5 + numFmts.Length).ToString() );
-            return sb.ToString();
+                /*
+                 * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{x.Format}"
+                 */
+                await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "numFmt", _context.OldXmlReader.NamespaceURI);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "formatCode", _context.OldXmlReader.NamespaceURI, item.Format);
+                await _context.NewXmlWriter.WriteFullEndElementAsync();
+            }
+        }
+
+        protected override void GenerateFont()
+        {
+            /*
+             * <x:font>
+             *     <x:vertAlign val="baseline" />
+             *     <x:sz val="11" />
+             *     <x:color rgb="FF000000" />
+             *     <x:name val="Calibri" />
+             *     <x:family val="2" />
+             * </x:font>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "baseline");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "11");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "Calibri");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "2");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:font>
+             *     <x:vertAlign val="baseline" />
+             *     <x:sz val="11" />
+             *     <x:color rgb="FFFFFFFF" />
+             *     <x:name val="Calibri" />
+             *     <x:family val="2" />
+             * </x:font>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "baseline");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "11");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FFFFFFFF");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "Calibri");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("val", "2");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+        }
+
+        protected override async Task GenerateFontAsync()
+        {
+            /*
+            * <x:font>
+            *     <x:vertAlign val="baseline" />
+            *     <x:sz val="11" />
+            *     <x:color rgb="FF000000" />
+            *     <x:name val="Calibri" />
+            *     <x:family val="2" />
+            * </x:font>
+            */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "baseline");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "11");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "Calibri");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "2");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:font>
+             *     <x:vertAlign val="baseline" />
+             *     <x:sz val="11" />
+             *     <x:color rgb="FFFFFFFF" />
+             *     <x:name val="Calibri" />
+             *     <x:family val="2" />
+             * </x:font>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "baseline");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "11");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FFFFFFFF");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "Calibri");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "2");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+        }
+
+        protected override void GenerateFill()
+        {
+            /*
+             * <x:fill>
+             *     <x:patternFill patternType="none" />
+             * </x:fill>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("patternType", "none");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:fill>
+             *     <x:patternFill patternType="gray125" />
+             * </x:fill>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("patternType", "gray125");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:fill>
+             *     <x:patternFill patternType="solid">
+             *         <x:fgColor rgb="284472C4" />
+             *     </x:patternFill>
+             * </x:fill>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("patternType", "solid");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fgColor", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "284472C4");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+        }
+
+        protected override async Task GenerateFillAsync()
+        {
+            /*
+            * <x:fill>
+            *     <x:patternFill patternType="none" />
+            * </x:fill>
+            */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:fill>
+             *     <x:patternFill patternType="gray125" />
+             * </x:fill>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "gray125");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:fill>
+             *     <x:patternFill patternType="solid">
+             *         <x:fgColor rgb="284472C4" />
+             *     </x:patternFill>
+             * </x:fill>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "solid");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fgColor", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "284472C4");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+        }
+
+        protected override void GenerateBorder()
+        {
+            /*
+             * <x:border diagonalUp="0" diagonalDown="0">
+             *     <x:left style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:left>
+             *     <x:right style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:right>
+             *     <x:top style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:top>
+             *     <x:bottom style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:bottom>
+             *     <x:diagonal style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:diagonal>
+             * </x:border>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("diagonalUp", "0");
+            _context.NewXmlWriter.WriteAttributeString("diagonalDown", "0");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:border diagonalUp="0" diagonalDown="0">
+             *     <x:left style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:left>
+             *     <x:right style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:right>
+             *     <x:top style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:top>
+             *     <x:bottom style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:bottom>
+             *     <x:diagonal style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:diagonal>
+             * </x:border>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("diagonalUp", "0");
+            _context.NewXmlWriter.WriteAttributeString("diagonalDown", "0");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "thin");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "thin");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "thin");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "thin");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("style", "none");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("rgb", "FF000000");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+        }
+
+        protected override async Task GenerateBorderAsync()
+        {
+            /*
+             * <x:border diagonalUp="0" diagonalDown="0">
+             *     <x:left style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:left>
+             *     <x:right style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:right>
+             *     <x:top style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:top>
+             *     <x:bottom style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:bottom>
+             *     <x:diagonal style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:diagonal>
+             * </x:border>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalUp", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalDown", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:border diagonalUp="0" diagonalDown="0">
+             *     <x:left style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:left>
+             *     <x:right style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:right>
+             *     <x:top style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:top>
+             *     <x:bottom style="thin">
+             *         <x:color rgb="FF000000" />
+             *     </x:bottom>
+             *     <x:diagonal style="none">
+             *         <x:color rgb="FF000000" />
+             *     </x:diagonal>
+             * </x:border>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalUp", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalDown", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+        }
+
+        protected override void GenerateCellStyleXf()
+        {
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyNumberFormat="1" applyFill="1" applyBorder="0" applyAlignment="1" applyProtection="1">
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "0");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="14" fontId="1" fillId="2" borderId="1" applyNumberFormat="1" applyFill="0" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "14");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 2}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "0");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+        }
+
+        protected override async Task GenerateCellStyleXfAsync()
+        {
+            /*
+            * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="0" applyNumberFormat="1" applyFill="1" applyBorder="0" applyAlignment="1" applyProtection="1">
+            *     <x:protection locked="1" hidden="0" />
+            * </x:xf>
+            */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="14" fontId="1" fillId="2" borderId="1" applyNumberFormat="1" applyFill="0" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "14");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 2}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+        }
+
+        protected override void GenerateCellXf()
+        {
+            /*
+             * <x:xf></x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="0" fontId="1" fillId="2" borderId="1" xfId="0" applyNumberFormat="1" applyFill="0" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="left" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "0");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 2}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("xfId", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("horizontal", "left");
+            _context.NewXmlWriter.WriteAttributeString("vertical", "bottom");
+            _context.NewXmlWriter.WriteAttributeString("textRotation", "0");
+            _context.NewXmlWriter.WriteAttributeString("wrapText", "0");
+            _context.NewXmlWriter.WriteAttributeString("indent", "0");
+            _context.NewXmlWriter.WriteAttributeString("relativeIndent", "0");
+            _context.NewXmlWriter.WriteAttributeString("justifyLastLine", "0");
+            _context.NewXmlWriter.WriteAttributeString("shrinkToFit", "0");
+            _context.NewXmlWriter.WriteAttributeString("readingOrder", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "0");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("xfId", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("horizontal", "general");
+            _context.NewXmlWriter.WriteAttributeString("vertical", "bottom");
+            _context.NewXmlWriter.WriteAttributeString("textRotation", "0");
+            _context.NewXmlWriter.WriteAttributeString("wrapText", "0");
+            _context.NewXmlWriter.WriteAttributeString("indent", "0");
+            _context.NewXmlWriter.WriteAttributeString("relativeIndent", "0");
+            _context.NewXmlWriter.WriteAttributeString("justifyLastLine", "0");
+            _context.NewXmlWriter.WriteAttributeString("shrinkToFit", "0");
+            _context.NewXmlWriter.WriteAttributeString("readingOrder", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="14" fontId="0" fillId="0" borderId="1" xfId="0" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "14");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("xfId", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyFill", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("horizontal", "general");
+            _context.NewXmlWriter.WriteAttributeString("vertical", "bottom");
+            _context.NewXmlWriter.WriteAttributeString("textRotation", "0");
+            _context.NewXmlWriter.WriteAttributeString("wrapText", "0");
+            _context.NewXmlWriter.WriteAttributeString("indent", "0");
+            _context.NewXmlWriter.WriteAttributeString("relativeIndent", "0");
+            _context.NewXmlWriter.WriteAttributeString("justifyLastLine", "0");
+            _context.NewXmlWriter.WriteAttributeString("shrinkToFit", "0");
+            _context.NewXmlWriter.WriteAttributeString("readingOrder", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("locked", "1");
+            _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1" applyAlignment="1">
+             *     <x:alignment horizontal="fill" />
+             * </x:xf>
+             */
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("numFmtId", "0");
+            _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+            _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+            _context.NewXmlWriter.WriteAttributeString("xfId", "0");
+            _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+            _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("horizontal", "fill");
+            _context.NewXmlWriter.WriteEndElement();
+            _context.NewXmlWriter.WriteEndElement();
+
+            const int numFmtIndex = 166;
+            var index = 0;
+            foreach (var item in _context.ColumnsToApply)
+            {
+                index++;
+
+                /*
+                 * <x:xf numFmtId=""{numFmtIndex + i}"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
+                 *     <x:alignment horizontal=""general"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
+                 *     <x:protection locked=""1"" hidden=""0"" />
+                 * </x:xf>
+                 */
+                _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+                _context.NewXmlWriter.WriteAttributeString("numFmtId", (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                _context.NewXmlWriter.WriteAttributeString("fontId", $"{_context.OldElementInfos.FontCount + 0}");
+                _context.NewXmlWriter.WriteAttributeString("fillId", $"{_context.OldElementInfos.FillCount + 0}");
+                _context.NewXmlWriter.WriteAttributeString("borderId", $"{_context.OldElementInfos.BorderCount + 1}");
+                _context.NewXmlWriter.WriteAttributeString("xfId", "0");
+                _context.NewXmlWriter.WriteAttributeString("applyNumberFormat", "1");
+                _context.NewXmlWriter.WriteAttributeString("applyFill", "1");
+                _context.NewXmlWriter.WriteAttributeString("applyBorder", "1");
+                _context.NewXmlWriter.WriteAttributeString("applyAlignment", "1");
+                _context.NewXmlWriter.WriteAttributeString("applyProtection", "1");
+                _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+                _context.NewXmlWriter.WriteAttributeString("horizontal", "general");
+                _context.NewXmlWriter.WriteAttributeString("vertical", "bottom");
+                _context.NewXmlWriter.WriteAttributeString("textRotation", "0");
+                _context.NewXmlWriter.WriteAttributeString("wrapText", "0");
+                _context.NewXmlWriter.WriteAttributeString("indent", "0");
+                _context.NewXmlWriter.WriteAttributeString("relativeIndent", "0");
+                _context.NewXmlWriter.WriteAttributeString("justifyLastLine", "0");
+                _context.NewXmlWriter.WriteAttributeString("shrinkToFit", "0");
+                _context.NewXmlWriter.WriteAttributeString("readingOrder", "0");
+                _context.NewXmlWriter.WriteEndElement();
+                _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+                _context.NewXmlWriter.WriteAttributeString("locked", "1");
+                _context.NewXmlWriter.WriteAttributeString("hidden", "0");
+                _context.NewXmlWriter.WriteEndElement();
+                _context.NewXmlWriter.WriteEndElement();
+            }
+        }
+
+        protected override async Task GenerateCellXfAsync()
+        {
+            /*
+             * <x:xf></x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="0" fontId="1" fillId="2" borderId="1" xfId="0" applyNumberFormat="1" applyFill="0" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="left" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 2}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "left");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="14" fontId="0" fillId="0" borderId="1" xfId="0" applyNumberFormat="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+             *     <x:alignment horizontal="general" vertical="bottom" textRotation="0" wrapText="0" indent="0" relativeIndent="0" justifyLastLine="0" shrinkToFit="0" readingOrder="0" />
+             *     <x:protection locked="1" hidden="0" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "14");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            /*
+             * <x:xf numFmtId="0" fontId="0" fillId="0" borderId="1" xfId="0" applyBorder="1" applyAlignment="1">
+             *     <x:alignment horizontal="fill" />
+             * </x:xf>
+             */
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "fill");
+            await _context.NewXmlWriter.WriteEndElementAsync();
+            await _context.NewXmlWriter.WriteEndElementAsync();
+
+            const int numFmtIndex = 166;
+            var index = 0;
+            foreach (var item in _context.ColumnsToApply)
+            {
+                index++;
+
+                /*
+                 * <x:xf numFmtId=""{numFmtIndex + i}"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
+                 *     <x:alignment horizontal=""general"" vertical=""bottom"" textRotation=""0"" wrapText=""0"" indent=""0"" relativeIndent=""0"" justifyLastLine=""0"" shrinkToFit=""0"" readingOrder=""0"" />
+                 *     <x:protection locked=""1"" hidden=""0"" />
+                 * </x:xf>
+                 */
+                await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteEndElementAsync();
+                await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteEndElementAsync();
+                await _context.NewXmlWriter.WriteEndElementAsync();
+            }
         }
     }
-
 }

--- a/src/MiniExcel/OpenXml/Styles/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel/OpenXml/Styles/DefaultSheetStyleBuilder.cs
@@ -57,8 +57,8 @@ namespace MiniExcelLibs.OpenXml.Styles
                  * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{x.Format}"
                  */
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "numFmt", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "formatCode", _context.OldXmlReader.NamespaceURI, item.Format);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString()); ;
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "formatCode", null, item.Format);
                 await _context.NewXmlWriter.WriteFullEndElementAsync();
             }
         }
@@ -133,19 +133,19 @@ namespace MiniExcelLibs.OpenXml.Styles
             */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "baseline");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "baseline");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "11");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "11");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "Calibri");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "Calibri");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "2");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "2");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -160,19 +160,19 @@ namespace MiniExcelLibs.OpenXml.Styles
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "font", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "vertAlign", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "baseline");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "baseline");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "sz", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "11");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "11");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FFFFFFFF");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FFFFFFFF");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "name", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "Calibri");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "Calibri");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "family", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "val", _context.OldXmlReader.NamespaceURI, "2");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "val", null, "2");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
         }
@@ -227,7 +227,7 @@ namespace MiniExcelLibs.OpenXml.Styles
             */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "patternType", null, "none");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -238,7 +238,7 @@ namespace MiniExcelLibs.OpenXml.Styles
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "gray125");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "patternType", null, "gray125");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -251,9 +251,9 @@ namespace MiniExcelLibs.OpenXml.Styles
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fill", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "patternFill", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "patternType", _context.OldXmlReader.NamespaceURI, "solid");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "patternType", null, "solid");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fgColor", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "284472C4");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "284472C4");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
@@ -392,36 +392,36 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:border>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalUp", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalDown", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "diagonalUp", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "diagonalDown", null, "0");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
@@ -446,36 +446,36 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:border>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "border", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalUp", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "diagonalDown", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "diagonalUp", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "diagonalDown", null, "0");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "left", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "thin");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "right", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "thin");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "top", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "thin");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "bottom", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "thin");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "thin");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "diagonal", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "style", _context.OldXmlReader.NamespaceURI, "none");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "style", null, "none");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "color", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "rgb", _context.OldXmlReader.NamespaceURI, "FF000000");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "rgb", null, "FF000000");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
@@ -555,18 +555,18 @@ namespace MiniExcelLibs.OpenXml.Styles
             * </x:xf>
             */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -576,18 +576,18 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "14");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 2}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "14");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 2}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -597,18 +597,18 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
         }
@@ -798,30 +798,30 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 2}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 2}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "xfId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "left");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "horizontal", null, "left");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "textRotation", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "wrapText", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "indent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "shrinkToFit", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "readingOrder", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -832,30 +832,30 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "xfId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "horizontal", null, "general");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "textRotation", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "wrapText", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "indent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "shrinkToFit", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "readingOrder", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -866,30 +866,30 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "14");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "14");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "xfId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "horizontal", null, "general");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "textRotation", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "wrapText", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "indent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "shrinkToFit", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "readingOrder", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -899,15 +899,15 @@ namespace MiniExcelLibs.OpenXml.Styles
              * </x:xf>
              */
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "xfId", null, "0");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "fill");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "horizontal", null, "fill");
             await _context.NewXmlWriter.WriteEndElementAsync();
             await _context.NewXmlWriter.WriteEndElementAsync();
 
@@ -924,30 +924,30 @@ namespace MiniExcelLibs.OpenXml.Styles
                  * </x:xf>
                  */
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fontId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FontCount + 0}");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "fillId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.FillCount + 0}");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "borderId", _context.OldXmlReader.NamespaceURI, $"{_context.OldElementInfos.BorderCount + 1}");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "xfId", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyFill", _context.OldXmlReader.NamespaceURI, "1");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyBorder", _context.OldXmlReader.NamespaceURI, "1");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyAlignment", _context.OldXmlReader.NamespaceURI, "1");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyProtection", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 0}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 0}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "xfId", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyFill", null, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1");
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "alignment", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "horizontal", _context.OldXmlReader.NamespaceURI, "general");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "vertical", _context.OldXmlReader.NamespaceURI, "bottom");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "textRotation", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "wrapText", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "indent", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "relativeIndent", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "justifyLastLine", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "shrinkToFit", _context.OldXmlReader.NamespaceURI, "0");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "readingOrder", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "horizontal", null, "general");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "textRotation", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "wrapText", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "indent", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "shrinkToFit", null, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "readingOrder", null, "0");
                 await _context.NewXmlWriter.WriteEndElementAsync();
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "protection", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "locked", _context.OldXmlReader.NamespaceURI, "1");
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "hidden", _context.OldXmlReader.NamespaceURI, "0");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "locked", null, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "hidden", null, "0");
                 await _context.NewXmlWriter.WriteEndElementAsync();
                 await _context.NewXmlWriter.WriteEndElementAsync();
             }

--- a/src/MiniExcel/OpenXml/Styles/ISheetStyleBuilder.cs
+++ b/src/MiniExcel/OpenXml/Styles/ISheetStyleBuilder.cs
@@ -1,10 +1,12 @@
-﻿using MiniExcelLibs.Attributes;
-using System.Collections.Generic;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
-namespace MiniExcelLibs.OpenXml.Styles {
-    public interface ISheetStyleBuilder
+namespace MiniExcelLibs.OpenXml.Styles
+{
+    internal interface ISheetStyleBuilder
     {
-        string Build( ICollection<ExcelColumnAttribute> columns );
-    }
+        SheetStyleBuildResult Build();
 
+        Task<SheetStyleBuildResult> BuildAsync(CancellationToken cancellationToken = default);
+    }
 }

--- a/src/MiniExcel/OpenXml/Styles/MinimalSheetStyleBuilder.cs
+++ b/src/MiniExcel/OpenXml/Styles/MinimalSheetStyleBuilder.cs
@@ -57,8 +57,8 @@ namespace MiniExcelLibs.OpenXml.Styles
                  * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{item.Format}" />
                  */
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "numFmt", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "formatCode", _context.OldXmlReader.NamespaceURI, item.Format);
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString());
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "formatCode", null, item.Format);
                 await _context.NewXmlWriter.WriteFullEndElementAsync();
             }
         }
@@ -189,8 +189,8 @@ namespace MiniExcelLibs.OpenXml.Styles
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteFullEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, "14");
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, "14");
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
             await _context.NewXmlWriter.WriteFullEndElementAsync();
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
             await _context.NewXmlWriter.WriteFullEndElementAsync();
@@ -205,8 +205,8 @@ namespace MiniExcelLibs.OpenXml.Styles
                  * <x:xf numFmtId="{numFmtIndex + i}" applyNumberFormat="1" 
                  */
                 await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "xf", _context.OldXmlReader.NamespaceURI);
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "numFmtId", _context.OldXmlReader.NamespaceURI, (numFmtIndex + index).ToString());
-                await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "applyNumberFormat", _context.OldXmlReader.NamespaceURI, "1");
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index).ToString());
+                await _context.NewXmlWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1");
                 await _context.NewXmlWriter.WriteFullEndElementAsync();
             }
         }

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleBuildContext.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleBuildContext.cs
@@ -1,0 +1,339 @@
+﻿using MiniExcelLibs.Attributes;
+using MiniExcelLibs.OpenXml.Constants;
+using MiniExcelLibs.Zip;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace MiniExcelLibs.OpenXml.Styles
+{
+    internal class SheetStyleBuildContext : IDisposable
+    {
+        private static readonly string _emptyStylesXml = ExcelOpenXmlUtils.MinifyXml
+        ($@"
+            <?xml version=""1.0"" encoding=""utf-8""?>
+            <x:styleSheet xmlns:x=""http://schemas.openxmlformats.org/spreadsheetml/2006/main"">                
+            </x:styleSheet>"
+        );
+
+        private readonly Dictionary<string, ZipPackageInfo> _zipDictionary;
+        private readonly MiniExcelZipArchive _archive;
+        private readonly Encoding _encoding;
+        private readonly ICollection<ExcelColumnAttribute> _columns;
+
+        private StringReader emptyStylesXmlStringReader;
+        private ZipArchiveEntry oldStyleXmlZipEntry;
+        private ZipArchiveEntry newStyleXmlZipEntry;
+        private Stream oldXmlReaderStream;
+        private Stream newXmlWriterStream;
+        private bool initialized = false;
+        private bool finalized = false;
+        private bool disposed = false;
+
+        public SheetStyleBuildContext(Dictionary<string, ZipPackageInfo> zipDictionary, MiniExcelZipArchive archive, Encoding encoding, ICollection<ExcelColumnAttribute> columns)
+        {
+            _zipDictionary = zipDictionary;
+            _archive = archive;
+            _encoding = encoding;
+            _columns = columns;
+        }
+
+        public XmlReader OldXmlReader { get; private set; }
+
+        public XmlWriter NewXmlWriter { get; private set; }
+
+        public SheetStyleElementInfos OldElementInfos { get; private set; }
+
+        public SheetStyleElementInfos GenerateElementInfos { get; private set; }
+
+        public IEnumerable<ExcelColumnAttribute> ColumnsToApply { get; private set; }
+
+        public int CustomFormatCount { get; private set; }
+
+        public void Initialize(SheetStyleElementInfos generateElementInfos)
+        {
+            if (initialized)
+            {
+                throw new InvalidOperationException("The context has been initialized.");
+            }
+
+            oldStyleXmlZipEntry = _archive.Mode == ZipArchiveMode.Update ? _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.Styles) : null;
+            if (oldStyleXmlZipEntry != null)
+            {
+                using (var oldStyleXmlStream = oldStyleXmlZipEntry.Open())
+                {
+                    OldElementInfos = ReadSheetStyleElementInfos(XmlReader.Create(oldStyleXmlStream, new XmlReaderSettings() { IgnoreWhitespace = true }));
+                }
+
+                oldXmlReaderStream = oldStyleXmlZipEntry.Open();
+                OldXmlReader = XmlReader.Create(oldXmlReaderStream, new XmlReaderSettings() { IgnoreWhitespace = true });
+
+                newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles + ".temp", CompressionLevel.Fastest);
+            }
+            else
+            {
+                OldElementInfos = new SheetStyleElementInfos();
+
+                emptyStylesXmlStringReader = new StringReader(_emptyStylesXml);
+                OldXmlReader = XmlReader.Create(emptyStylesXmlStringReader, new XmlReaderSettings() { IgnoreWhitespace = true });
+
+                newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
+            }
+
+            newXmlWriterStream = newStyleXmlZipEntry.Open();
+            NewXmlWriter = XmlWriter.Create(newXmlWriterStream, new XmlWriterSettings() { Indent = true, Encoding = _encoding });
+
+            GenerateElementInfos = generateElementInfos;
+            ColumnsToApply = SheetStyleBuilderHelper.GenerateStyleIds(OldElementInfos.CellXfCount + generateElementInfos.CellXfCount, _columns).ToArray();//这里暂时加ToArray，避免多次计算，如果有性能问题再考虑优化
+            CustomFormatCount = ColumnsToApply.Count();
+
+            initialized = true;
+        }
+
+        public async Task InitializeAsync(SheetStyleElementInfos generateElementInfos)
+        {
+            if (initialized)
+            {
+                throw new InvalidOperationException("The context has been initialized.");
+            }
+
+            oldStyleXmlZipEntry = _archive.Mode == ZipArchiveMode.Update ? _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.Styles) : null;
+            if (oldStyleXmlZipEntry != null)
+            {
+                using (var oldStyleXmlStream = oldStyleXmlZipEntry.Open())
+                {
+                    OldElementInfos = await ReadSheetStyleElementInfosAsync(XmlReader.Create(oldStyleXmlStream, new XmlReaderSettings() { IgnoreWhitespace = true, Async = true }));
+                }
+                oldXmlReaderStream = oldStyleXmlZipEntry.Open();
+                OldXmlReader = XmlReader.Create(oldXmlReaderStream, new XmlReaderSettings() { IgnoreWhitespace = true, Async = true });
+
+                newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles + ".temp", CompressionLevel.Fastest);
+            }
+            else
+            {
+                OldElementInfos = new SheetStyleElementInfos();
+                emptyStylesXmlStringReader = new StringReader(_emptyStylesXml);
+                OldXmlReader = XmlReader.Create(emptyStylesXmlStringReader, new XmlReaderSettings() { IgnoreWhitespace = true, Async = true });
+
+                newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
+            }
+
+            newXmlWriterStream = newStyleXmlZipEntry.Open();
+            NewXmlWriter = XmlWriter.Create(newXmlWriterStream, new XmlWriterSettings() { Indent = true, Encoding = _encoding, Async = true });
+
+            GenerateElementInfos = generateElementInfos;
+            ColumnsToApply = SheetStyleBuilderHelper.GenerateStyleIds(OldElementInfos.CellXfCount + generateElementInfos.CellXfCount, _columns);
+            CustomFormatCount = ColumnsToApply.Count();
+
+            initialized = true;
+        }
+
+        public void FinalizeAndUpdateZipDictionary()
+        {
+            if (!initialized)
+            {
+                throw new InvalidOperationException("The context has not been initialized.");
+            }
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(SheetStyleBuildContext));
+            }
+            if (finalized)
+            {
+                throw new InvalidOperationException("The context has been finalized.");
+            }
+            try
+            {
+                OldXmlReader.Dispose();
+                OldXmlReader = null;
+                oldXmlReaderStream?.Dispose();
+                oldXmlReaderStream = null;
+                emptyStylesXmlStringReader?.Dispose();
+                emptyStylesXmlStringReader = null;
+
+                NewXmlWriter.Flush();
+                NewXmlWriter.Close();
+                NewXmlWriter.Dispose();
+                NewXmlWriter = null;
+                newXmlWriterStream.Dispose();
+                newXmlWriterStream = null;
+
+                if (oldStyleXmlZipEntry == null)
+                {
+                    _zipDictionary.Add(ExcelFileNames.Styles, new ZipPackageInfo(newStyleXmlZipEntry, ExcelContentTypes.Styles));
+                }
+                else
+                {
+                    oldStyleXmlZipEntry?.Delete();
+                    oldStyleXmlZipEntry = null;
+                    var finalStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
+                    using (var tempStream = newStyleXmlZipEntry.Open())
+                    using (var newStream = finalStyleXmlZipEntry.Open())
+                    {
+                        tempStream.CopyTo(newStream);
+                    }
+                    _zipDictionary[ExcelFileNames.Styles] = new ZipPackageInfo(finalStyleXmlZipEntry, ExcelContentTypes.Styles);
+                    newStyleXmlZipEntry.Delete();
+                    newStyleXmlZipEntry = null;
+                }
+
+                finalized = true;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to finalize and replace styles.", ex);
+            }
+        }
+
+        public async Task FinalizeAndUpdateZipDictionaryAsync()
+        {
+            if (!initialized)
+            {
+                throw new InvalidOperationException("The context has not been initialized.");
+            }
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(SheetStyleBuildContext));
+            }
+            if (finalized)
+            {
+                throw new InvalidOperationException("The context has been finalized.");
+            }
+            try
+            {
+                OldXmlReader.Dispose();
+                OldXmlReader = null;
+                oldXmlReaderStream?.Dispose();
+                oldXmlReaderStream = null;
+                emptyStylesXmlStringReader?.Dispose();
+                emptyStylesXmlStringReader = null;
+
+                await NewXmlWriter.FlushAsync();
+                NewXmlWriter.Close();
+                NewXmlWriter.Dispose();
+                NewXmlWriter = null;
+                newXmlWriterStream.Dispose();
+                newXmlWriterStream = null;
+
+                if (oldStyleXmlZipEntry == null)
+                {
+                    _zipDictionary.Add(ExcelFileNames.Styles, new ZipPackageInfo(newStyleXmlZipEntry, ExcelContentTypes.Styles));
+                }
+                else
+                {
+                    oldStyleXmlZipEntry?.Delete();
+                    oldStyleXmlZipEntry = null;
+                    var finalStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
+                    using (var tempStream = newStyleXmlZipEntry.Open())
+                    using (var newStream = finalStyleXmlZipEntry.Open())
+                    {
+                        await tempStream.CopyToAsync(newStream);
+                    }
+                    _zipDictionary[ExcelFileNames.Styles] = new ZipPackageInfo(finalStyleXmlZipEntry, ExcelContentTypes.Styles);
+                    newStyleXmlZipEntry.Delete();
+                    newStyleXmlZipEntry = null;
+                }
+
+                finalized = true;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Failed to finalize and replace styles.", ex);
+            }
+        }
+
+        private static SheetStyleElementInfos ReadSheetStyleElementInfos(XmlReader reader)
+        {
+            var elementInfos = new SheetStyleElementInfos();
+            while (reader.Read())
+            {
+                SetElementInfos(reader, elementInfos);
+            }
+            return elementInfos;
+        }
+
+        private static async Task<SheetStyleElementInfos> ReadSheetStyleElementInfosAsync(XmlReader reader)
+        {
+            var elementInfos = new SheetStyleElementInfos();
+            while (await reader.ReadAsync())
+            {
+                SetElementInfos(reader, elementInfos);
+            }
+            return elementInfos;
+        }
+
+        private static void SetElementInfos(XmlReader reader, SheetStyleElementInfos elementInfos)
+        {
+            if (reader.NodeType == XmlNodeType.Element)
+            {
+                switch (reader.LocalName)
+                {
+                    case "numFmts":
+                        elementInfos.ExistsNumFmts = true;
+                        elementInfos.NumFmtCount = GetCount();
+                        break;
+                    case "fonts":
+                        elementInfos.ExistsFonts = true;
+                        elementInfos.FontCount = GetCount();
+                        break;
+                    case "fills":
+                        elementInfos.ExistsFills = true;
+                        elementInfos.FillCount = GetCount();
+                        break;
+                    case "borders":
+                        elementInfos.ExistsBorders = true;
+                        elementInfos.BorderCount = GetCount();
+                        break;
+                    case "cellStyleXfs":
+                        elementInfos.ExistsCellStyleXfs = true;
+                        elementInfos.CellStyleXfCount = GetCount();
+                        break;
+                    case "cellXfs":
+                        elementInfos.ExistsCellXfs = true;
+                        elementInfos.CellXfCount = GetCount();
+                        break;
+                }
+
+                int GetCount()
+                {
+                    string count = reader.GetAttribute("count");
+                    if (!string.IsNullOrEmpty(count) && int.TryParse(count, out int countValue))
+                    {
+                        return countValue;
+                    }
+                    return 0;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    OldXmlReader?.Dispose();
+                    oldXmlReaderStream?.Dispose();
+                    emptyStylesXmlStringReader?.Dispose();
+
+                    NewXmlWriter?.Dispose();
+                    newXmlWriterStream?.Dispose();
+                }
+
+                disposed = true;
+            }
+        }
+    }
+}

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleBuildResult.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleBuildResult.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace MiniExcelLibs.OpenXml.Styles
+{
+    internal class SheetStyleBuildResult
+    {
+        public SheetStyleBuildResult(Dictionary<string, string> cellXfIdMap)
+        {
+            CellXfIdMap = cellXfIdMap;
+        }
+
+        public Dictionary<string, string> CellXfIdMap { get; set; }
+    }
+}

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
@@ -103,7 +103,7 @@ namespace MiniExcelLibs.OpenXml.Styles
                         await WriteAttributesAsync(_context.OldXmlReader.LocalName);
                         if (_context.OldXmlReader.IsEmptyElement)
                         {
-                            GenerateElementBeforEndElement();
+                            await GenerateElementBeforEndElementAsync();
                             await _context.NewXmlWriter.WriteEndElementAsync();
                         }
                         break;
@@ -131,7 +131,7 @@ namespace MiniExcelLibs.OpenXml.Styles
                         await _context.NewXmlWriter.WriteCommentAsync(_context.OldXmlReader.Value);
                         break;
                     case XmlNodeType.EndElement:
-                        GenerateElementBeforEndElement();
+                        await GenerateElementBeforEndElementAsync();
                         await _context.NewXmlWriter.WriteFullEndElementAsync();
                         break;
                 }
@@ -420,7 +420,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateNumFmtsAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "numFmts", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
             await GenerateNumFmtAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
 
@@ -450,7 +450,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateFontsAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fonts", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
             await GenerateFontAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
 
@@ -479,7 +479,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateFillsAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fills", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
             await GenerateFillAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
 
@@ -509,7 +509,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateBordersAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "borders", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
             await GenerateBorderAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
 
@@ -539,7 +539,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateCellStyleXfsAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "cellStyleXfs", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
             await GenerateCellStyleXfAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
 
@@ -564,7 +564,7 @@ namespace MiniExcelLibs.OpenXml.Styles
         protected virtual async Task GenerateCellXfsAsync()
         {
             await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "cellXfs", _context.OldXmlReader.NamespaceURI);
-            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
+            await _context.NewXmlWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
             await GenerateCellXfAsync();
             await _context.NewXmlWriter.WriteFullEndElementAsync();
         }

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
@@ -1,0 +1,566 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace MiniExcelLibs.OpenXml.Styles
+{
+    internal abstract class SheetStyleBuilderBase: ISheetStyleBuilder
+    {
+        internal readonly static HashSet<string> _afterCellXfsElements = new HashSet<string> { "cellStyles", "dxfs", "tableStyles", "extLst" };
+
+        private readonly SheetStyleBuildContext _context;
+
+        public SheetStyleBuilderBase(SheetStyleBuildContext context)
+        {
+            _context = context;
+        }
+
+        public virtual SheetStyleBuildResult Build()
+        {
+            _context.Initialize(GetGenerateElementInfos());
+
+            while (_context.OldXmlReader.Read())
+            {
+                switch (_context.OldXmlReader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        GenerateElementBeforStartElement();
+                        _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, _context.OldXmlReader.LocalName, _context.OldXmlReader.NamespaceURI);
+                        WriteAttributes(_context.OldXmlReader.LocalName);
+                        if (_context.OldXmlReader.IsEmptyElement)
+                        {
+                            GenerateElementBeforEndElement();
+                            _context.NewXmlWriter.WriteEndElement();
+                        }
+                        break;
+
+                    case XmlNodeType.Text:
+                        _context.NewXmlWriter.WriteString(_context.OldXmlReader.Value);
+                        break;
+
+                    case XmlNodeType.Whitespace:
+                    case XmlNodeType.SignificantWhitespace:
+                        _context.NewXmlWriter.WriteWhitespace(_context.OldXmlReader.Value);
+                        break;
+
+                    case XmlNodeType.CDATA:
+                        _context.NewXmlWriter.WriteCData(_context.OldXmlReader.Value);
+                        break;
+
+                    case XmlNodeType.EntityReference:
+                        _context.NewXmlWriter.WriteEntityRef(_context.OldXmlReader.Name);
+                        break;
+
+                    case XmlNodeType.XmlDeclaration:
+                    case XmlNodeType.ProcessingInstruction:
+                        _context.NewXmlWriter.WriteProcessingInstruction(_context.OldXmlReader.Name, _context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.DocumentType:
+                        _context.NewXmlWriter.WriteDocType(_context.OldXmlReader.Name, _context.OldXmlReader.GetAttribute("PUBLIC"), _context.OldXmlReader.GetAttribute("SYSTEM"), _context.OldXmlReader.Value);
+                        break;
+
+                    case XmlNodeType.Comment:
+                        _context.NewXmlWriter.WriteComment(_context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.EndElement:
+                        GenerateElementBeforEndElement();
+                        _context.NewXmlWriter.WriteFullEndElement();
+                        break;
+                }
+            }
+
+            _context.FinalizeAndUpdateZipDictionary();
+
+            return new SheetStyleBuildResult(GetCellXfIdMap());
+        }
+
+        public virtual async Task<SheetStyleBuildResult> BuildAsync(CancellationToken cancellationToken = default)
+        {
+            await _context.InitializeAsync(GetGenerateElementInfos());
+
+            while (await _context.OldXmlReader.ReadAsync())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                switch (_context.OldXmlReader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        await GenerateElementBeforStartElementAsync();
+                        await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, _context.OldXmlReader.LocalName, _context.OldXmlReader.NamespaceURI);
+                        await WriteAttributesAsync(_context.OldXmlReader.LocalName);
+                        if (_context.OldXmlReader.IsEmptyElement)
+                        {
+                            GenerateElementBeforEndElement();
+                            await _context.NewXmlWriter.WriteEndElementAsync();
+                        }
+                        break;
+                    case XmlNodeType.Text:
+                        await _context.NewXmlWriter.WriteStringAsync(_context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.Whitespace:
+                    case XmlNodeType.SignificantWhitespace:
+                        await _context.NewXmlWriter.WriteWhitespaceAsync(_context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.CDATA:
+                        await _context.NewXmlWriter.WriteCDataAsync(_context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.EntityReference:
+                        await _context.NewXmlWriter.WriteEntityRefAsync(_context.OldXmlReader.Name);
+                        break;
+                    case XmlNodeType.XmlDeclaration:
+                    case XmlNodeType.ProcessingInstruction:
+                        await _context.NewXmlWriter.WriteProcessingInstructionAsync(_context.OldXmlReader.Name, _context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.DocumentType:
+                        await _context.NewXmlWriter.WriteDocTypeAsync(_context.OldXmlReader.Name, _context.OldXmlReader.GetAttribute("PUBLIC"), _context.OldXmlReader.GetAttribute("SYSTEM"), _context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.Comment:
+                        await _context.NewXmlWriter.WriteCommentAsync(_context.OldXmlReader.Value);
+                        break;
+                    case XmlNodeType.EndElement:
+                        GenerateElementBeforEndElement();
+                        await _context.NewXmlWriter.WriteFullEndElementAsync();
+                        break;
+                }
+            }
+
+            await _context.FinalizeAndUpdateZipDictionaryAsync();
+
+            return new SheetStyleBuildResult(GetCellXfIdMap());
+        }
+
+        protected abstract SheetStyleElementInfos GetGenerateElementInfos();
+
+        protected virtual void WriteAttributes(string element)
+        {
+            if (_context.OldXmlReader.NodeType is XmlNodeType.Element || _context.OldXmlReader.NodeType is XmlNodeType.XmlDeclaration)
+            {
+                if (_context.OldXmlReader.MoveToFirstAttribute())
+                {
+                    WriteAttributes(element);
+                    _context.OldXmlReader.MoveToElement();
+                }
+            }
+            else if (_context.OldXmlReader.NodeType == XmlNodeType.Attribute)
+            {
+                do
+                {
+                    _context.NewXmlWriter.WriteStartAttribute(_context.OldXmlReader.Prefix, _context.OldXmlReader.LocalName, _context.OldXmlReader.NamespaceURI);
+                    var currentAttribute = _context.OldXmlReader.LocalName;
+                    while (_context.OldXmlReader.ReadAttributeValue())
+                    {
+                        if (_context.OldXmlReader.NodeType == XmlNodeType.EntityReference)
+                        {
+                            _context.NewXmlWriter.WriteEntityRef(_context.OldXmlReader.Name);
+                        }
+                        else if (currentAttribute == "count")
+                        {
+                            switch (element)
+                            {
+                                case "numFmts":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
+                                    break;
+                                case "fonts":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
+                                    break;
+                                case "fills":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
+                                    break;
+                                case "borders":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
+                                    break;
+                                case "cellStyleXfs":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
+                                    break;
+                                case "cellXfs":
+                                    _context.NewXmlWriter.WriteString((_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
+                                    break;
+                                default:
+                                    _context.NewXmlWriter.WriteString(_context.OldXmlReader.Value);
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            _context.NewXmlWriter.WriteString(_context.OldXmlReader.Value);
+                        }
+                    }
+                    _context.NewXmlWriter.WriteEndAttribute();
+                }
+                while (_context.OldXmlReader.MoveToNextAttribute());
+            }
+        }
+
+        protected virtual async Task WriteAttributesAsync(string element)
+        {
+            if (_context.OldXmlReader.NodeType is XmlNodeType.Element || _context.OldXmlReader.NodeType is XmlNodeType.XmlDeclaration)
+            {
+                if (_context.OldXmlReader.MoveToFirstAttribute())
+                {
+                    await WriteAttributesAsync(element);
+                    _context.OldXmlReader.MoveToElement();
+                }
+            }
+            else if (_context.OldXmlReader.NodeType == XmlNodeType.Attribute)
+            {
+                do
+                {
+                    _context.NewXmlWriter.WriteStartAttribute(_context.OldXmlReader.Prefix, _context.OldXmlReader.LocalName, _context.OldXmlReader.NamespaceURI);
+                    var currentAttribute = _context.OldXmlReader.LocalName;
+                    while (_context.OldXmlReader.ReadAttributeValue())
+                    {
+                        if (_context.OldXmlReader.NodeType == XmlNodeType.EntityReference)
+                        {
+                            await _context.NewXmlWriter.WriteEntityRefAsync(_context.OldXmlReader.Name);
+                        }
+                        else if (currentAttribute == "count")
+                        {
+                            switch (element)
+                            {
+                                case "numFmts":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
+                                    break;
+                                case "fonts":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
+                                    break;
+                                case "fills":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
+                                    break;
+                                case "borders":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
+                                    break;
+                                case "cellStyleXfs":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
+                                    break;
+                                case "cellXfs":
+                                    await _context.NewXmlWriter.WriteStringAsync((_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
+                                    break;
+                                default:
+                                    await _context.NewXmlWriter.WriteStringAsync(_context.OldXmlReader.Value);
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            await _context.NewXmlWriter.WriteStringAsync(_context.OldXmlReader.Value);
+                        }
+                    }
+                    _context.NewXmlWriter.WriteEndAttribute();
+                }
+                while (_context.OldXmlReader.MoveToNextAttribute());
+            }
+        }
+
+        protected virtual void GenerateElementBeforStartElement()
+        {
+            if (_context.OldXmlReader.LocalName == "fonts" && !_context.OldElementInfos.ExistsNumFmts)
+            {
+                GenerateNumFmts();
+                _context.GenerateElementInfos.ExistsNumFmts = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "fills" && !_context.OldElementInfos.ExistsFonts)
+            {
+                GenerateFonts();
+                _context.GenerateElementInfos.ExistsFonts = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "borders" && !_context.OldElementInfos.ExistsFills)
+            {
+                GenerateFills();
+                _context.GenerateElementInfos.ExistsFills = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "cellStyleXfs" && !_context.OldElementInfos.ExistsBorders)
+            {
+                GenerateBorders();
+                _context.GenerateElementInfos.ExistsBorders = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "cellXfs" && !_context.OldElementInfos.ExistsCellStyleXfs)
+            {
+                GenerateCellStyleXfs();
+                _context.GenerateElementInfos.ExistsCellStyleXfs = true;
+            }
+            else if (_afterCellXfsElements.Contains(_context.OldXmlReader.LocalName) && !_context.OldElementInfos.ExistsCellXfs && _context.GenerateElementInfos.ExistsCellXfs)
+            {
+                GenerateCellXfs();
+                _context.GenerateElementInfos.ExistsCellXfs = true;
+            }
+        }
+
+        protected virtual async Task GenerateElementBeforStartElementAsync()
+        {
+            if (_context.OldXmlReader.LocalName == "fonts" && !_context.OldElementInfos.ExistsNumFmts)
+            {
+                await GenerateNumFmtsAsync();
+                _context.GenerateElementInfos.ExistsNumFmts = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "fills" && !_context.OldElementInfos.ExistsFonts)
+            {
+                await GenerateFontsAsync();
+                _context.GenerateElementInfos.ExistsFonts = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "borders" && !_context.OldElementInfos.ExistsFills)
+            {
+                await GenerateFillsAsync();
+                _context.GenerateElementInfos.ExistsFills = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "cellStyleXfs" && !_context.OldElementInfos.ExistsBorders)
+            {
+                await GenerateBordersAsync();
+                _context.GenerateElementInfos.ExistsBorders = true;
+            }
+            else if (_context.OldXmlReader.LocalName == "cellXfs" && !_context.OldElementInfos.ExistsCellStyleXfs)
+            {
+                await GenerateCellStyleXfsAsync();
+                _context.GenerateElementInfos.ExistsCellStyleXfs = true;
+            }
+            else if (_afterCellXfsElements.Contains(_context.OldXmlReader.LocalName) && !_context.OldElementInfos.ExistsCellXfs && _context.GenerateElementInfos.ExistsCellXfs)
+            {
+                await GenerateCellXfsAsync();
+                _context.GenerateElementInfos.ExistsCellXfs = true;
+            }
+        }
+
+        protected virtual void GenerateElementBeforEndElement()
+        {
+            if (_context.OldXmlReader.LocalName == "numFmts")
+            {
+                GenerateNumFmt();
+            }
+            else if (_context.OldXmlReader.LocalName == "fonts")
+            {
+                GenerateFont();
+            }
+            else if (_context.OldXmlReader.LocalName == "fills")
+            {
+                GenerateFill();
+            }
+            else if (_context.OldXmlReader.LocalName == "borders")
+            {
+                GenerateBorder();
+            }
+            else if (_context.OldXmlReader.LocalName == "cellStyleXfs")
+            {
+                GenerateCellStyleXf();
+            }
+            else if (_context.OldXmlReader.LocalName == "cellXfs")
+            {
+                GenerateCellXf();
+            }
+            else if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
+            {
+                GenerateNumFmts();
+            }
+        }
+
+        protected virtual async Task GenerateElementBeforEndElementAsync()
+        {
+            if (_context.OldXmlReader.LocalName == "numFmts")
+            {
+                await GenerateNumFmtAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "fonts")
+            {
+                await GenerateFontAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "fills")
+            {
+                await GenerateFillAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "borders")
+            {
+                await GenerateBorderAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "cellStyleXfs")
+            {
+                await GenerateCellStyleXfAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "cellXfs")
+            {
+                await GenerateCellXfAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
+            {
+                await GenerateNumFmtsAsync();
+            }
+        }
+
+        protected virtual void GenerateNumFmts()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "numFmts", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
+            GenerateNumFmt();
+            _context.NewXmlWriter.WriteFullEndElement();
+
+            if (!_context.OldElementInfos.ExistsFonts)
+            {
+                GenerateFonts();
+            }
+        }
+
+        protected virtual async Task GenerateNumFmtsAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "numFmts", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.NumFmtCount + _context.GenerateElementInfos.NumFmtCount + _context.CustomFormatCount).ToString());
+            await GenerateNumFmtAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+
+            if (!_context.OldElementInfos.ExistsFonts)
+            {
+                await GenerateFontsAsync();
+            }
+        }
+
+        protected abstract void GenerateNumFmt();
+
+        protected abstract Task GenerateNumFmtAsync();
+
+        protected virtual void GenerateFonts()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fonts", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
+            GenerateFont();
+            _context.NewXmlWriter.WriteFullEndElement();
+
+            if (!_context.OldElementInfos.ExistsFills)
+            {
+                GenerateFills();
+            }
+        }
+
+        protected virtual async Task GenerateFontsAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fonts", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.FontCount + _context.GenerateElementInfos.FontCount).ToString());
+            await GenerateFontAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+
+            if (!_context.OldElementInfos.ExistsFills)
+            {
+                await GenerateFillsAsync();
+            }
+        }
+
+        protected abstract void GenerateFont();
+
+        protected abstract Task GenerateFontAsync();
+
+        protected virtual void GenerateFills()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "fills", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
+            GenerateFill();
+            _context.NewXmlWriter.WriteFullEndElement();
+            if (!_context.OldElementInfos.ExistsBorders)
+            {
+                GenerateBorders();
+            }
+        }
+
+        protected virtual async Task GenerateFillsAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "fills", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.FillCount + _context.GenerateElementInfos.FillCount).ToString());
+            await GenerateFillAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+
+            if (!_context.OldElementInfos.ExistsBorders)
+            {
+                await GenerateBordersAsync();
+            }
+        }
+
+        protected abstract void GenerateFill();
+
+        protected abstract Task GenerateFillAsync();
+
+        protected virtual void GenerateBorders()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "borders", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
+            GenerateBorder();
+            _context.NewXmlWriter.WriteFullEndElement();
+
+            if (!_context.OldElementInfos.ExistsCellStyleXfs)
+            {
+                GenerateCellStyleXfs();
+            }
+        }
+
+        protected virtual async Task GenerateBordersAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "borders", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.BorderCount + _context.GenerateElementInfos.BorderCount).ToString());
+            await GenerateBorderAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+
+            if (!_context.OldElementInfos.ExistsCellStyleXfs)
+            {
+                await GenerateCellStyleXfsAsync();
+            }
+        }
+
+        protected abstract void GenerateBorder();
+
+        protected abstract Task GenerateBorderAsync();
+
+        protected virtual void GenerateCellStyleXfs()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "cellStyleXfs", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
+            GenerateCellStyleXf();
+            _context.NewXmlWriter.WriteFullEndElement();
+
+            if (!_context.OldElementInfos.ExistsCellXfs)
+            {
+                GenerateCellXfs();
+            }
+        }
+
+        protected virtual async Task GenerateCellStyleXfsAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "cellStyleXfs", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.CellStyleXfCount + _context.GenerateElementInfos.CellStyleXfCount).ToString());
+            await GenerateCellStyleXfAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+
+            if (!_context.OldElementInfos.ExistsCellXfs)
+            {
+                await GenerateCellXfsAsync();
+            }
+        }
+
+        protected abstract void GenerateCellStyleXf();
+
+        protected abstract Task GenerateCellStyleXfAsync();
+
+        protected virtual void GenerateCellXfs()
+        {
+            _context.NewXmlWriter.WriteStartElement(_context.OldXmlReader.Prefix, "cellXfs", _context.OldXmlReader.NamespaceURI);
+            _context.NewXmlWriter.WriteAttributeString("count", (_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
+            GenerateCellXf();
+            _context.NewXmlWriter.WriteFullEndElement();
+        }
+
+        protected virtual async Task GenerateCellXfsAsync()
+        {
+            await _context.NewXmlWriter.WriteStartElementAsync(_context.OldXmlReader.Prefix, "cellXfs", _context.OldXmlReader.NamespaceURI);
+            await _context.NewXmlWriter.WriteAttributeStringAsync(_context.OldXmlReader.Prefix, "count", _context.OldXmlReader.NamespaceURI, (_context.OldElementInfos.CellXfCount + _context.GenerateElementInfos.CellXfCount + _context.CustomFormatCount).ToString());
+            await GenerateCellXfAsync();
+            await _context.NewXmlWriter.WriteFullEndElementAsync();
+        }
+
+        protected abstract void GenerateCellXf();
+
+        protected abstract Task GenerateCellXfAsync();
+
+        private Dictionary<string, string> GetCellXfIdMap()
+        {
+            var result = new Dictionary<string, string>();
+            for (int i = 0; i < _context.GenerateElementInfos.CellXfCount; i++)
+            {
+                result.Add(i.ToString(), (_context.OldElementInfos.CellXfCount + i).ToString());
+            }
+            return result;
+        }
+    }
+}

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleBuilderBase.cs
@@ -5,9 +5,21 @@ using System.Xml;
 
 namespace MiniExcelLibs.OpenXml.Styles
 {
-    internal abstract class SheetStyleBuilderBase: ISheetStyleBuilder
+    internal abstract class SheetStyleBuilderBase : ISheetStyleBuilder
     {
-        internal readonly static HashSet<string> _afterCellXfsElements = new HashSet<string> { "cellStyles", "dxfs", "tableStyles", "extLst" };
+        internal readonly static Dictionary<string, int> _allElements = new Dictionary<string, int>
+        {
+            ["numFmts"] = 0,
+            ["fonts"] = 1,
+            ["fills"] = 2,
+            ["borders"] = 3,
+            ["cellStyleXfs"] = 4,
+            ["cellXfs"] = 5,
+            ["cellStyles"] = 6,
+            ["dxfs"] = 7,
+            ["tableStyles"] = 8,
+            ["extLst"] = 9
+        };
 
         private readonly SheetStyleBuildContext _context;
 
@@ -254,32 +266,36 @@ namespace MiniExcelLibs.OpenXml.Styles
 
         protected virtual void GenerateElementBeforStartElement()
         {
-            if (_context.OldXmlReader.LocalName == "fonts" && !_context.OldElementInfos.ExistsNumFmts)
+            if (!_allElements.TryGetValue(_context.OldXmlReader.LocalName, out var elementIndex))
+            {
+                return;
+            }
+            if (!_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts && _allElements["numFmts"] < elementIndex)
             {
                 GenerateNumFmts();
                 _context.GenerateElementInfos.ExistsNumFmts = true;
             }
-            else if (_context.OldXmlReader.LocalName == "fills" && !_context.OldElementInfos.ExistsFonts)
+            else if (!_context.OldElementInfos.ExistsFonts && !_context.GenerateElementInfos.ExistsFonts && _allElements["fonts"] < elementIndex)
             {
                 GenerateFonts();
                 _context.GenerateElementInfos.ExistsFonts = true;
             }
-            else if (_context.OldXmlReader.LocalName == "borders" && !_context.OldElementInfos.ExistsFills)
+            else if (!_context.OldElementInfos.ExistsFills && !_context.GenerateElementInfos.ExistsFills && _allElements["fills"] < elementIndex)
             {
                 GenerateFills();
                 _context.GenerateElementInfos.ExistsFills = true;
             }
-            else if (_context.OldXmlReader.LocalName == "cellStyleXfs" && !_context.OldElementInfos.ExistsBorders)
+            else if (!_context.OldElementInfos.ExistsBorders && !_context.GenerateElementInfos.ExistsBorders && _allElements["borders"] < elementIndex)
             {
                 GenerateBorders();
                 _context.GenerateElementInfos.ExistsBorders = true;
             }
-            else if (_context.OldXmlReader.LocalName == "cellXfs" && !_context.OldElementInfos.ExistsCellStyleXfs)
+            else if (!_context.OldElementInfos.ExistsCellStyleXfs && !_context.GenerateElementInfos.ExistsCellStyleXfs && _allElements["cellStyleXfs"] < elementIndex)
             {
                 GenerateCellStyleXfs();
                 _context.GenerateElementInfos.ExistsCellStyleXfs = true;
             }
-            else if (_afterCellXfsElements.Contains(_context.OldXmlReader.LocalName) && !_context.OldElementInfos.ExistsCellXfs && _context.GenerateElementInfos.ExistsCellXfs)
+            else if (!_context.OldElementInfos.ExistsCellXfs && !_context.GenerateElementInfos.ExistsCellXfs && _allElements["cellXfs"] < elementIndex)
             {
                 GenerateCellXfs();
                 _context.GenerateElementInfos.ExistsCellXfs = true;
@@ -288,32 +304,36 @@ namespace MiniExcelLibs.OpenXml.Styles
 
         protected virtual async Task GenerateElementBeforStartElementAsync()
         {
-            if (_context.OldXmlReader.LocalName == "fonts" && !_context.OldElementInfos.ExistsNumFmts)
+            if (!_allElements.TryGetValue(_context.OldXmlReader.LocalName, out var elementIndex))
+            {
+                return;
+            }
+            if (!_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts && _allElements["numFmts"] < elementIndex)
             {
                 await GenerateNumFmtsAsync();
                 _context.GenerateElementInfos.ExistsNumFmts = true;
             }
-            else if (_context.OldXmlReader.LocalName == "fills" && !_context.OldElementInfos.ExistsFonts)
+            else if (!_context.OldElementInfos.ExistsFonts && !_context.GenerateElementInfos.ExistsFonts && _allElements["fonts"] < elementIndex)
             {
                 await GenerateFontsAsync();
                 _context.GenerateElementInfos.ExistsFonts = true;
             }
-            else if (_context.OldXmlReader.LocalName == "borders" && !_context.OldElementInfos.ExistsFills)
+            else if (!_context.OldElementInfos.ExistsFills && !_context.GenerateElementInfos.ExistsFills && _allElements["fills"] < elementIndex)
             {
                 await GenerateFillsAsync();
                 _context.GenerateElementInfos.ExistsFills = true;
             }
-            else if (_context.OldXmlReader.LocalName == "cellStyleXfs" && !_context.OldElementInfos.ExistsBorders)
+            else if (!_context.OldElementInfos.ExistsBorders && !_context.GenerateElementInfos.ExistsBorders && _allElements["borders"] < elementIndex)
             {
                 await GenerateBordersAsync();
                 _context.GenerateElementInfos.ExistsBorders = true;
             }
-            else if (_context.OldXmlReader.LocalName == "cellXfs" && !_context.OldElementInfos.ExistsCellStyleXfs)
+            else if (!_context.OldElementInfos.ExistsCellStyleXfs && !_context.GenerateElementInfos.ExistsCellStyleXfs && _allElements["cellStyleXfs"] < elementIndex)
             {
                 await GenerateCellStyleXfsAsync();
                 _context.GenerateElementInfos.ExistsCellStyleXfs = true;
             }
-            else if (_afterCellXfsElements.Contains(_context.OldXmlReader.LocalName) && !_context.OldElementInfos.ExistsCellXfs && _context.GenerateElementInfos.ExistsCellXfs)
+            else if (!_context.OldElementInfos.ExistsCellXfs && !_context.GenerateElementInfos.ExistsCellXfs && _allElements["cellXfs"] < elementIndex)
             {
                 await GenerateCellXfsAsync();
                 _context.GenerateElementInfos.ExistsCellXfs = true;
@@ -322,7 +342,11 @@ namespace MiniExcelLibs.OpenXml.Styles
 
         protected virtual void GenerateElementBeforEndElement()
         {
-            if (_context.OldXmlReader.LocalName == "numFmts")
+            if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
+            {
+                GenerateNumFmts();
+            }
+            else if (_context.OldXmlReader.LocalName == "numFmts")
             {
                 GenerateNumFmt();
             }
@@ -346,15 +370,15 @@ namespace MiniExcelLibs.OpenXml.Styles
             {
                 GenerateCellXf();
             }
-            else if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
-            {
-                GenerateNumFmts();
-            }
         }
 
         protected virtual async Task GenerateElementBeforEndElementAsync()
         {
-            if (_context.OldXmlReader.LocalName == "numFmts")
+            if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
+            {
+                await GenerateNumFmtsAsync();
+            }
+            else if (_context.OldXmlReader.LocalName == "numFmts")
             {
                 await GenerateNumFmtAsync();
             }
@@ -377,10 +401,6 @@ namespace MiniExcelLibs.OpenXml.Styles
             else if (_context.OldXmlReader.LocalName == "cellXfs")
             {
                 await GenerateCellXfAsync();
-            }
-            else if (_context.OldXmlReader.LocalName == "styleSheet" && !_context.OldElementInfos.ExistsNumFmts && !_context.GenerateElementInfos.ExistsNumFmts)
-            {
-                await GenerateNumFmtsAsync();
             }
         }
 

--- a/src/MiniExcel/OpenXml/Styles/SheetStyleElementInfos.cs
+++ b/src/MiniExcel/OpenXml/Styles/SheetStyleElementInfos.cs
@@ -1,0 +1,29 @@
+﻿namespace MiniExcelLibs.OpenXml.Styles
+{
+    public class SheetStyleElementInfos
+    {
+        public bool ExistsNumFmts { get; set; }
+
+        public int NumFmtCount { get; set; }
+
+        public bool ExistsFonts { get; set; }
+
+        public int FontCount { get; set; }
+
+        public bool ExistsFills { get; set; }
+
+        public int FillCount { get; set; }
+
+        public bool ExistsBorders { get; set; }
+
+        public int BorderCount { get; set; }
+
+        public bool ExistsCellStyleXfs { get; set; }
+
+        public int CellStyleXfCount { get; set; }
+
+        public bool ExistsCellXfs { get; set; }
+
+        public int CellXfCount { get; set; }
+    }
+}

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -1455,5 +1455,141 @@ namespace MiniExcelLibs.Tests
                 Assert.Equal(onlyDate.ToDateTime(TimeOnly.MinValue), (DateTime)rows[1]["Column4"]);
             }
         }
+
+        [Fact]
+        public void InsertSheetTest()
+        {
+            var now = DateTime.Now;
+            var path = PathHelper.GetTempPath();
+            {
+                var table = new DataTable();
+                {
+                    table.Columns.Add("a", typeof(string));
+                    table.Columns.Add("b", typeof(decimal));
+                    table.Columns.Add("c", typeof(bool));
+                    table.Columns.Add("d", typeof(DateTime));
+                    table.Rows.Add(@"""<>+-*//}{\\n", 1234567890, true, now);
+                    table.Rows.Add(@"<test>Hello World</test>", -1234567890, false, now.Date);
+                }
+
+                MiniExcel.Insert(path, table, sheetName: "Sheet1");
+                using (var p = new ExcelPackage(new FileInfo(path)))
+                {
+                    var sheet1 = p.Workbook.Worksheets[0];
+
+                    Assert.True(sheet1.Cells["A1"].Value.ToString() == "a");
+                    Assert.True(sheet1.Cells["B1"].Value.ToString() == "b");
+                    Assert.True(sheet1.Cells["C1"].Value.ToString() == "c");
+                    Assert.True(sheet1.Cells["D1"].Value.ToString() == "d");
+
+                    Assert.True(sheet1.Cells["A2"].Value.ToString() == @"""<>+-*//}{\\n");
+                    Assert.True(sheet1.Cells["B2"].Value.ToString() == @"1234567890");
+                    Assert.True(sheet1.Cells["C2"].Value.ToString() == true.ToString());
+                    Assert.True(sheet1.Cells["D2"].Value.ToString() == now.ToString());
+
+                    Assert.True(sheet1.Name == "Sheet1");
+                }
+            }
+            {
+                var table = new DataTable();
+                {
+                    table.Columns.Add("Column1", typeof(string));
+                    table.Columns.Add("Column2", typeof(int));
+                    table.Rows.Add("MiniExcel", 1);
+                    table.Rows.Add("Github", 2);
+                }
+
+                MiniExcel.Insert(path, table, sheetName: "Sheet2");
+                using (var p = new ExcelPackage(new FileInfo(path)))
+                {
+                    var sheet2 = p.Workbook.Worksheets[1];
+
+                    Assert.True(sheet2.Cells["A1"].Value.ToString() == "Column1");
+                    Assert.True(sheet2.Cells["B1"].Value.ToString() == "Column2");
+
+                    Assert.True(sheet2.Cells["A2"].Value.ToString() == "MiniExcel");
+                    Assert.True(sheet2.Cells["B2"].Value.ToString() == "1");
+
+                    Assert.True(sheet2.Cells["A3"].Value.ToString() == "Github");
+                    Assert.True(sheet2.Cells["B3"].Value.ToString() == "2");
+
+                    Assert.True(sheet2.Name == "Sheet2");
+                }
+            }
+            {
+                var table = new DataTable();
+                {
+                    table.Columns.Add("Column1", typeof(string));
+                    table.Columns.Add("Column2", typeof(DateTime));
+                    table.Rows.Add("Test", now);
+                }
+
+                MiniExcel.Insert(path, table, sheetName: "Sheet2", printHeader: false, configuration: new OpenXmlConfiguration
+                {
+                    FastMode = true,
+                    AutoFilter = false,
+                    TableStyles = TableStyles.None,
+                    DynamicColumns = new[]
+                    {
+                        new DynamicExcelColumn("Column2")
+                        {
+                            Name = "Its Date",
+                            Index = 1,
+                            Width = 150,
+                            Format = "dd.mm.yyyy hh:mm:ss",
+                        }
+                    }
+                }, overwriteSheet: true);
+                using (var p = new ExcelPackage(new FileInfo(path)))
+                {
+                    var sheet2 = p.Workbook.Worksheets[1];
+
+                    Assert.True(sheet2.Cells["A1"].Value.ToString() == "Test");
+                    Assert.True(sheet2.Cells["B1"].Text == now.ToString("dd.MM.yyyy HH:mm:ss"));
+                    Assert.True(sheet2.Name == "Sheet2");
+                }
+            }
+            {
+                var table = new DataTable();
+                {
+                    table.Columns.Add("Column1", typeof(string));
+                    table.Columns.Add("Column2", typeof(DateTime));
+                    table.Rows.Add("MiniExcel", now);
+                    table.Rows.Add("Github", now);
+                }
+
+                MiniExcel.Insert(path, table, sheetName: "Sheet3", configuration: new OpenXmlConfiguration
+                {
+                    FastMode = true,
+                    AutoFilter = false,
+                    TableStyles = TableStyles.None,
+                    DynamicColumns = new[]
+                    {
+                        new DynamicExcelColumn("Column2")
+                        {
+                            Name = "Its Date",
+                            Index = 1,
+                            Width = 150,
+                            Format = "dd.mm.yyyy hh:mm:ss",
+                        }
+                    }
+                });
+                using (var p = new ExcelPackage(new FileInfo(path)))
+                {
+                    var sheet3 = p.Workbook.Worksheets[2];
+
+                    Assert.True(sheet3.Cells["A1"].Value.ToString() == "Column1");
+                    Assert.True(sheet3.Cells["B1"].Value.ToString() == "Its Date");
+
+                    Assert.True(sheet3.Cells["A2"].Value.ToString() == "MiniExcel");
+                    Assert.True(sheet3.Cells["B2"].Text == now.ToString("dd.MM.yyyy HH:mm:ss"));
+
+                    Assert.True(sheet3.Cells["A3"].Value.ToString() == "Github");
+                    Assert.True(sheet3.Cells["B3"].Text == now.ToString("dd.MM.yyyy HH:mm:ss"));
+
+                    Assert.True(sheet3.Name == "Sheet3");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
close #646 , #551

- 重构了 `SheetStyleBuilder` 以实现新增Sheet，使用 `XmlReader` 读取旧style.xml，使用 `XmlWriter` 在旧的基础上进行最追加修改style.xml
- 必须使用FastMode，因为要Update压缩包
- 新增 `SheetStyleElementInfos` 用于记录新旧style.xml的Element简要信息，方便修改逻辑处理
- 新增 `SheetStyleBuildContext` 用于记录Build上下文信息，方便修改逻辑处理
- 新增 `SheetStyleBuildResult` 用于记录Build结果，这里会输出一个 `CellXfIdMap`，因为新增Sheet会导致创建Cell要设置的样式Id发生偏移，这里做了一个映射，这样就可以正确的应用新增的CellXf了