### PR TITLE
Generalize excel writing with a common write adapter and implement writing IAsyncEnumerable

### DIFF
--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -109,7 +109,7 @@ namespace MiniExcelLibs.Csv
             {
                 writeAdapter = MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
             }
-            var props = writeAdapter?.GetColumns() ?? await asyncWriteAdapter.GetColumnsAsync();
+            var props = writeAdapter != null ? writeAdapter.GetColumns() : await asyncWriteAdapter.GetColumnsAsync();
 #else
             IMiniExcelWriteAdapter writeAdapter =  MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
             var props = writeAdapter.GetColumns();

--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -53,9 +53,9 @@ namespace MiniExcelLibs.Csv
             rowBuilder.Append(_configuration.Seperator);
         }
 
-        private void RemoveTrailingSeparator(StringBuilder rowBuilder) 
+        private void RemoveTrailingSeparator(StringBuilder rowBuilder)
         {
-            if (rowBuilder.Length == 0) 
+            if (rowBuilder.Length == 0)
             {
                 return;
             }
@@ -68,9 +68,15 @@ namespace MiniExcelLibs.Csv
 
         private void WriteValues(StreamWriter writer, object values)
         {
-            IMiniExcelWriteAdapter writeAdapter =  MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
+            IMiniExcelWriteAdapter writeAdapter = MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
 
             var props = writeAdapter.GetColumns();
+            if (props == null)
+            {
+                _writer.Write(_configuration.NewLine);
+                _writer.Flush();
+                return;
+            }
 
             if (_printHeader)
             {
@@ -108,7 +114,12 @@ namespace MiniExcelLibs.Csv
             IMiniExcelWriteAdapter writeAdapter =  MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
             var props = writeAdapter.GetColumns();
 #endif
-
+            if (props == null)
+            {
+                await _writer.WriteAsync(_configuration.NewLine);
+                await _writer.FlushAsync();
+                return;
+            }
             if (_printHeader)
             {
                 await _writer.WriteAsync(GetHeader(props));

--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -35,9 +35,6 @@ Todo : https://github.com/mini-software/MiniExcel/projects/1?fullscreen=true</De
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
-		<Reference Include="System.IO.Compression" />
-	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
 		<Reference Include="System.IO.Compression" />
 	</ItemGroup>

--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -3,6 +3,9 @@
 		<TargetFrameworks>net45;netstandard2.0;net8.0;</TargetFrameworks>
 		<Version>1.36.1</Version>
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<LangVersion>8</LangVersion>
+	</PropertyGroup>
 	<PropertyGroup>
 		<AssemblyName>MiniExcel</AssemblyName>
 		<Company>Mini-Software</Company>
@@ -52,5 +55,10 @@ Todo : https://github.com/mini-software/MiniExcel/projects/1?fullscreen=true</De
 	</ItemGroup>
 	<ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+	    <Version>9.0.0</Version>
+	  </PackageReference>
 	</ItemGroup>
 </Project>

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -115,7 +115,7 @@ namespace MiniExcelLibs.OpenXml
                 }
                 else
                 {
-                    await WriteValuesAsync(writer, values);
+                    await WriteValuesAsync(writer, values, cancellationToken);
                 }
             }
             _zipDictionary.Add(sheetPath, new ZipPackageInfo(entry, ExcelContentTypes.Worksheet));
@@ -180,7 +180,7 @@ namespace MiniExcelLibs.OpenXml
             }
         }
 
-        private async Task WriteValuesAsync(MiniExcelAsyncStreamWriter writer, object values)
+        private async Task WriteValuesAsync(MiniExcelAsyncStreamWriter writer, object values, CancellationToken cancellationToken)
         {
 #if NETSTANDARD2_0_OR_GREATER || NET
             IMiniExcelWriteAdapter writeAdapter = null;
@@ -249,7 +249,7 @@ namespace MiniExcelLibs.OpenXml
 
             if (writeAdapter != null)
             {
-                foreach (var row in writeAdapter.GetRows(props))
+                foreach (var row in writeAdapter.GetRows(props, cancellationToken))
                 {
                     await writer.WriteAsync(WorksheetXml.StartRow(currentRowIndex));
                     foreach (var cellValue in row)
@@ -264,7 +264,7 @@ namespace MiniExcelLibs.OpenXml
 #if NETSTANDARD2_0_OR_GREATER || NET
             else
             {
-                await foreach (var row in asyncWriteAdapter.GetRowsAsync(props))
+                await foreach (var row in asyncWriteAdapter.GetRowsAsync(props, cancellationToken))
                 {
                     await writer.WriteAsync(WorksheetXml.StartRow(currentRowIndex));
                     await foreach (var cellValue in row)

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -7,6 +7,7 @@ using MiniExcelLibs.Zip;
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -162,13 +162,13 @@ namespace MiniExcelLibs.OpenXml
             var props = writeAdapter.GetColumns();
 #endif
 
-            var maxColumnIndex = props.Count;
-            int maxRowIndex;
             if (props == null)
             {
                 await WriteEmptySheetAsync(writer);
                 return;
             }
+            var maxColumnIndex = props.Count;
+            int maxRowIndex;
 
             await writer.WriteAsync(WorksheetXml.StartWorksheetWithRelationship);
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -152,7 +152,8 @@ namespace MiniExcelLibs.OpenXml
                 writeAdapter = MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
             }
 
-            var isKnownCount = writeAdapter != null && writeAdapter.TryGetKnownCount(out var count);
+            var count = 0;
+            var isKnownCount = writeAdapter != null && writeAdapter.TryGetKnownCount(out count);
             var props = writeAdapter?.GetColumns() ?? await asyncWriteAdapter.GetColumnsAsync();
 #else
             IMiniExcelWriteAdapter writeAdapter =  MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -154,7 +154,7 @@ namespace MiniExcelLibs.OpenXml
 
             var count = 0;
             var isKnownCount = writeAdapter != null && writeAdapter.TryGetKnownCount(out count);
-            var props = writeAdapter?.GetColumns() ?? await asyncWriteAdapter.GetColumnsAsync();
+            var props = writeAdapter != null ? writeAdapter?.GetColumns() : await asyncWriteAdapter.GetColumnsAsync();
 #else
             IMiniExcelWriteAdapter writeAdapter =  MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefaultOpenXml.cs
@@ -177,73 +177,6 @@ namespace MiniExcelLibs.OpenXml
 
         }
 
-        private ExcelColumnInfo GetColumnInfosFromDynamicConfiguration(string columnName)
-        {
-            var prop = new ExcelColumnInfo
-            {
-                ExcelColumnName = columnName,
-                Key = columnName
-            };
-
-            if (_configuration.DynamicColumns == null || _configuration.DynamicColumns.Length <= 0)
-                return prop;
-
-            var dynamicColumn = _configuration.DynamicColumns.SingleOrDefault(_ => string.Equals(_.Key, columnName, StringComparison.OrdinalIgnoreCase));
-            if (dynamicColumn == null || dynamicColumn.Ignore)
-            {
-                return prop;
-            }
-
-            prop.Nullable = true;
-            prop.ExcelIgnore = dynamicColumn.Ignore;
-            prop.ExcelColumnType = dynamicColumn.Type;
-            prop.ExcelColumnIndex = dynamicColumn.Index;
-            prop.ExcelColumnWidth = dynamicColumn.Width;
-            prop.CustomFormatter = dynamicColumn.CustomFormatter;
-            //prop.ExcludeNullableType = item2[key]?.GetType();
-
-            if (dynamicColumn.Format != null)
-            {
-                prop.ExcelFormat = dynamicColumn.Format;
-                prop.ExcelFormatId = dynamicColumn.FormatId;
-            }
-
-            if (dynamicColumn.Aliases != null)
-            {
-                prop.ExcelColumnAliases = dynamicColumn.Aliases;
-            }
-
-            if (dynamicColumn.IndexName != null)
-            {
-                prop.ExcelIndexName = dynamicColumn.IndexName;
-            }
-
-            if (dynamicColumn.Name != null)
-            {
-                prop.ExcelColumnName = dynamicColumn.Name;
-            }
-
-            return prop;
-        }
-
-        private void SetGenericTypePropertiesMode(Type genericType, ref string mode, out int maxColumnIndex, out List<ExcelColumnInfo> props)
-        {
-            mode = "Properties";
-            if (genericType.IsValueType)
-            {
-                throw new NotImplementedException($"MiniExcel not support only {genericType.Name} value generic type");
-            }
-
-            if (genericType == typeof(string) || genericType == typeof(DateTime) || genericType == typeof(Guid))
-            {
-                throw new NotImplementedException($"MiniExcel not support only {genericType.Name} generic type");
-            }
-
-            props = CustomPropertyHelper.GetSaveAsProperties(genericType, _configuration);
-
-            maxColumnIndex = props.Count;
-        }
-
         private Tuple<string, string, string> GetCellValue(int rowIndex, int cellIndex, object value, ExcelColumnInfo columnInfo, bool valueIsNull)
         {
             if (valueIsNull)
@@ -446,7 +379,7 @@ namespace MiniExcelLibs.OpenXml
             string dimensionRef;
             if (maxRowIndex == 0 && maxColumnIndex == 0)
                 dimensionRef = "A1";
-            else if (maxColumnIndex == 1)
+            else if (maxColumnIndex <= 1)
                 dimensionRef = $"A{maxRowIndex}";
             else if (maxRowIndex == 0)
                 dimensionRef = $"A1:{ColumnHelper.GetAlphabetColumnName(maxColumnIndex - 1)}1";

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -8,10 +8,8 @@ using MiniExcelLibs.Zip;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Text;
 
 namespace MiniExcelLibs.OpenXml
@@ -183,7 +181,7 @@ namespace MiniExcelLibs.OpenXml
 
         private void WriteValues(MiniExcelStreamWriter writer, object values)
         {
-            IMiniExcelWriteAdapter writeAdapter = GetExcelWriteAdapter(values, _configuration);
+            IMiniExcelWriteAdapter writeAdapter = MiniExcelWriteAdapterFactory.GetWriteAdapter(values, _configuration);
 
             var hasCount = writeAdapter.TryGetNonEnumeratedCount(out var count);
             var props = writeAdapter.GetColumns();

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -183,17 +183,17 @@ namespace MiniExcelLibs.OpenXml
 
         private void WriteValues(MiniExcelStreamWriter writer, object values)
         {
-            IExcelWriteAdapter writeAdapter;
+            IMiniExcelWriteAdapter writeAdapter;
             switch (values)
             {
                 case IDataReader dataReader:
-                    writeAdapter = new DataReaderExcelWriteAdapter(dataReader, _configuration);
+                    writeAdapter = new DataReaderWriteAdapter(dataReader, _configuration);
                     break;
                 case IEnumerable enumerable:
                     writeAdapter = new EnumerableWriteAdapter(enumerable, _configuration);
                     break;
                 case DataTable dataTable:
-                    writeAdapter = new DataTableExcelWriteAdapter(dataTable, _configuration);
+                    writeAdapter = new DataTableWriteAdapter(dataTable, _configuration);
                     break;
                 default:
                     throw new NotImplementedException();

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -185,13 +185,13 @@ namespace MiniExcelLibs.OpenXml
 
             var isKnownCount = writeAdapter.TryGetKnownCount(out var count);
             var props = writeAdapter.GetColumns();
-            var maxColumnIndex = props.Count;
-            int maxRowIndex;
             if (props == null)
             {
                 WriteEmptySheet(writer);
                 return;
             }
+            var maxColumnIndex = props.Count;
+            int maxRowIndex;
 
             writer.Write(WorksheetXml.StartWorksheetWithRelationship);
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -183,21 +183,7 @@ namespace MiniExcelLibs.OpenXml
 
         private void WriteValues(MiniExcelStreamWriter writer, object values)
         {
-            IMiniExcelWriteAdapter writeAdapter;
-            switch (values)
-            {
-                case IDataReader dataReader:
-                    writeAdapter = new DataReaderWriteAdapter(dataReader, _configuration);
-                    break;
-                case IEnumerable enumerable:
-                    writeAdapter = new EnumerableWriteAdapter(enumerable, _configuration);
-                    break;
-                case DataTable dataTable:
-                    writeAdapter = new DataTableWriteAdapter(dataTable, _configuration);
-                    break;
-                default:
-                    throw new NotImplementedException();
-            }
+            IMiniExcelWriteAdapter writeAdapter = GetExcelWriteAdapter(values, _configuration);
 
             var hasCount = writeAdapter.TryGetNonEnumeratedCount(out var count);
             var props = writeAdapter.GetColumns();

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -3,6 +3,7 @@ using MiniExcelLibs.OpenXml.Constants;
 using MiniExcelLibs.OpenXml.Models;
 using MiniExcelLibs.OpenXml.Styles;
 using MiniExcelLibs.Utils;
+using MiniExcelLibs.WriteAdapter;
 using MiniExcelLibs.Zip;
 using System;
 using System.Collections;
@@ -137,36 +138,19 @@ namespace MiniExcelLibs.OpenXml
             GenerateStylesXml();
         }
 
-        private void CreateSheetXml(object value, string sheetPath)
+        private void CreateSheetXml(object values, string sheetPath)
         {
             ZipArchiveEntry entry = _archive.CreateEntry(sheetPath, CompressionLevel.Fastest);
             using (var zipStream = entry.Open())
             using (MiniExcelStreamWriter writer = new MiniExcelStreamWriter(zipStream, _utf8WithBom, _configuration.BufferSize))
             {
-                if (value == null)
+                if (values == null)
                 {
                     WriteEmptySheet(writer);
                 }
                 else
                 {
-                    //DapperRow
-
-                    if (value is IDataReader)
-                    {
-                        GenerateSheetByIDataReader(writer, value as IDataReader);
-                    }
-                    else if (value is IEnumerable)
-                    {
-                        GenerateSheetByEnumerable(writer, value as IEnumerable);
-                    }
-                    else if (value is DataTable)
-                    {
-                        GenerateSheetByDataTable(writer, value as DataTable);
-                    }
-                    else
-                    {
-                        throw new NotImplementedException($"Type {value.GetType().FullName} is not implemented. Please open an issue.");
-                    }
+                    WriteValues(writer, values);
                 }
             }
             _zipDictionary.Add(sheetPath, new ZipPackageInfo(entry, ExcelContentTypes.Worksheet));
@@ -196,154 +180,33 @@ namespace MiniExcelLibs.OpenXml
             writer.SetPosition(position);
         }
 
-        private void GenerateSheetByIDataReader(MiniExcelStreamWriter writer, IDataReader reader)
+
+        private void WriteValues(MiniExcelStreamWriter writer, object values)
         {
-            long dimensionPlaceholderPosition = 0;
-            writer.Write(WorksheetXml.StartWorksheet);
-            var yIndex = 1;
-            int maxColumnIndex;
+            IExcelWriteAdapter writeAdapter;
+            switch (values)
+            {
+                case IDataReader dataReader:
+                    writeAdapter = new DataReaderExcelWriteAdapter(dataReader, _configuration);
+                    break;
+                case IEnumerable enumerable:
+                    writeAdapter = new EnumerableWriteAdapter(enumerable, _configuration);
+                    break;
+                case DataTable dataTable:
+                    writeAdapter = new DataTableExcelWriteAdapter(dataTable, _configuration);
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+
+            var hasCount = writeAdapter.TryGetNonEnumeratedCount(out var count);
+            var props = writeAdapter.GetColumns();
+            var maxColumnIndex = props.Count;
             int maxRowIndex;
-            ExcelWidthCollection widths = null;
-            long columnWidthsPlaceholderPosition = 0;
+            if (props.Count == 0)
             {
-                if (_configuration.FastMode)
-                {
-                    dimensionPlaceholderPosition = WriteDimensionPlaceholder(writer);
-                }
-
-                var props = new List<ExcelColumnInfo>();
-                for (var i = 0; i < reader.FieldCount; i++)
-                {
-                    var columnName = reader.GetName(i);
-                    var prop = GetColumnInfosFromDynamicConfiguration(columnName);
-                    props.Add(prop);
-                }
-                maxColumnIndex = props.Count;
-
-                //sheet view
-                writer.Write(GetSheetViews());
-
-                if (_configuration.EnableAutoWidth)
-                {
-                    columnWidthsPlaceholderPosition = WriteColumnWidthPlaceholders(writer, props);
-                    widths = new ExcelWidthCollection(_configuration.MinWidth, _configuration.MaxWidth, props);
-                }
-                else
-                {
-                    WriteColumnsWidths(writer, ExcelColumnWidth.FromProps(props));
-                }
-
-                writer.Write(WorksheetXml.StartSheetData);
-                int fieldCount = reader.FieldCount;
-                if (_printHeader)
-                {
-                    PrintHeader(writer, props);
-                    if (props.Count > 0)
-                    {
-                        yIndex++;
-                    }
-                }
-
-                while (reader.Read())
-                {
-                    writer.Write(WorksheetXml.StartRow(yIndex));
-                    var xIndex = 1;
-                    for (int i = 0; i < fieldCount; i++)
-                    {
-                        var cellValue = reader.GetValue(i);
-                        WriteCell(writer, yIndex, xIndex, cellValue, columnInfo: props?.FirstOrDefault(x => x?.ExcelColumnIndex == xIndex - 1), widths);
-                        xIndex++;
-                    }
-                    writer.Write(WorksheetXml.EndRow);
-                    yIndex++;
-                }
-
-                // Subtract 1 because cell indexing starts with 1
-                maxRowIndex = yIndex - 1;
-            }
-            writer.Write(WorksheetXml.EndSheetData);
-
-            if (_configuration.AutoFilter)
-            {
-                writer.Write(WorksheetXml.Autofilter(GetDimensionRef(maxRowIndex, maxColumnIndex)));
-            }
-
-            writer.WriteAndFlush(WorksheetXml.EndWorksheet);
-
-            if (_configuration.FastMode)
-            {
-                WriteDimension(writer, maxRowIndex, maxColumnIndex, dimensionPlaceholderPosition);
-            }
-
-            if (_configuration.EnableAutoWidth)
-            {
-                OverWriteColumnWidthPlaceholders(writer, columnWidthsPlaceholderPosition, widths.Columns);
-            }
-
-        }
-
-        private void GenerateSheetByEnumerable(MiniExcelStreamWriter writer, IEnumerable values)
-        {
-            var maxRowIndex = 0;
-            string mode = null;
-
-            int? rowCount = null;
-            var collection = values as ICollection;
-            if (collection != null)
-            {
-                rowCount = collection.Count;
-            }
-            else if (!_configuration.FastMode)
-            {
-                // The row count is only required up front when not in fastmode
-                collection = new List<object>(values.Cast<object>());
-                rowCount = collection.Count;
-            }
-
-            // Get the enumerator once to ensure deferred linq execution
-            var enumerator = (collection ?? values).GetEnumerator();
-
-            // Move to the first item in order to inspect the value type and determine whether it is empty
-            var empty = !enumerator.MoveNext();
-
-            int maxColumnIndex;
-            List<ExcelColumnInfo> props;
-            if (empty)
-            {
-                // only when empty IEnumerable need to check this issue #133  https://github.com/shps951023/MiniExcel/issues/133
-                var genericType = TypeHelper.GetGenericIEnumerables(values).FirstOrDefault();
-                if (genericType == null || genericType == typeof(object) // sometime generic type will be object, e.g: https://user-images.githubusercontent.com/12729184/132812859-52984314-44d1-4ee8-9487-2d1da159f1f0.png
-                    || typeof(IDictionary<string, object>).IsAssignableFrom(genericType)
-                    || typeof(IDictionary).IsAssignableFrom(genericType))
-                {
-                    WriteEmptySheet(writer);
-                    return;
-                }
-                else
-                {
-                    SetGenericTypePropertiesMode(genericType, ref mode, out maxColumnIndex, out props);
-                }
-            }
-            else
-            {
-                var firstItem = enumerator.Current;
-                if (firstItem is IDictionary<string, object> genericDic)
-                {
-                    mode = "IDictionary<string, object>";
-                    props = CustomPropertyHelper.GetDictionaryColumnInfo(genericDic, null, _configuration);
-                    maxColumnIndex = props.Count;
-                }
-                else if (firstItem is IDictionary dic)
-                {
-                    mode = "IDictionary";
-                    props = CustomPropertyHelper.GetDictionaryColumnInfo(null, dic, _configuration);
-                    //maxColumnIndex = dic.Keys.Count;
-                    maxColumnIndex = props.Count; // why not using keys, because ignore attribute ![image](https://user-images.githubusercontent.com/12729184/163686902-286abb70-877b-4e84-bd3b-001ad339a84a.png)
-                }
-                else
-                {
-                    SetGenericTypePropertiesMode(firstItem.GetType(), ref mode, out maxColumnIndex, out props);
-                }
+                WriteEmptySheet(writer);
+                return;
             }
 
             writer.Write(WorksheetXml.StartWorksheetWithRelationship);
@@ -351,14 +214,14 @@ namespace MiniExcelLibs.OpenXml
             long dimensionPlaceholderPostition = 0;
 
             // We can write the dimensions directly if the row count is known
-            if (_configuration.FastMode && rowCount == null)
+            if (_configuration.FastMode && !hasCount)
             {
                 dimensionPlaceholderPostition = WriteDimensionPlaceholder(writer);
             }
             else
             {
-                maxRowIndex = rowCount.Value + (_printHeader && rowCount > 0 ? 1 : 0);
-                writer.Write(WorksheetXml.Dimension(GetDimensionRef(maxRowIndex, maxColumnIndex)));
+                maxRowIndex = count + (_printHeader && count > 0 ? 1 : 0);
+                writer.Write(WorksheetXml.Dimension(GetDimensionRef(maxRowIndex, props.Count)));
             }
 
             //sheet view
@@ -379,34 +242,28 @@ namespace MiniExcelLibs.OpenXml
 
             //header
             writer.Write(WorksheetXml.StartSheetData);
-            var yIndex = 1;
-            var xIndex = 1;
+            var currentRowIndex = 0;
             if (_printHeader)
             {
                 PrintHeader(writer, props);
-                yIndex++;
+                currentRowIndex++;
             }
 
-            if (!empty)
+            foreach (var row in writeAdapter.GetRows(props))
             {
-                // body
-                switch (mode)
+                writer.Write(WorksheetXml.StartRow(++currentRowIndex));
+                foreach (var cellValue in row)
                 {
-                    case "IDictionary<string, object>": //Dapper Row
-                        maxRowIndex = GenerateSheetByColumnInfo<IDictionary<string, object>>(writer, enumerator, props, widths, xIndex, yIndex);
-                        break;
-                    case "IDictionary":
-                        maxRowIndex = GenerateSheetByColumnInfo<IDictionary>(writer, enumerator, props, widths, xIndex, yIndex);
-                        break;
-                    case "Properties":
-                        maxRowIndex = GenerateSheetByColumnInfo<object>(writer, enumerator, props, widths, xIndex, yIndex);
-                        break;
-                    default:
-                        throw new NotImplementedException($"Type {values.GetType().FullName} is not implemented. Please open an issue.");
+                    WriteCell(writer, currentRowIndex, cellValue.CellIndex, cellValue.Value, cellValue.Prop, widths);
                 }
+                writer.Write(WorksheetXml.EndRow);
+
+                ;
             }
+            maxRowIndex = currentRowIndex;
 
             writer.Write(WorksheetXml.EndSheetData);
+
             if (_configuration.AutoFilter)
             {
                 writer.Write(WorksheetXml.Autofilter(GetDimensionRef(maxRowIndex, maxColumnIndex)));
@@ -415,100 +272,16 @@ namespace MiniExcelLibs.OpenXml
             writer.Write(WorksheetXml.Drawing(currentSheetIndex));
             writer.Write(WorksheetXml.EndWorksheet);
 
-            // The dimension has already been written if row count is defined
-            if (_configuration.FastMode && rowCount == null)
+            if (_configuration.FastMode && dimensionPlaceholderPostition != default)
             {
                 WriteDimension(writer, maxRowIndex, maxColumnIndex, dimensionPlaceholderPostition);
             }
-
             if (_configuration.EnableAutoWidth)
             {
                 OverWriteColumnWidthPlaceholders(writer, columnWidthsPlaceholderPosition, widths.Columns);
             }
         }
 
-        private void GenerateSheetByDataTable(MiniExcelStreamWriter writer, DataTable value)
-        {
-            var xy = ExcelOpenXmlUtils.ConvertCellToXY("A1");
-
-            //GOTO Top Write:
-            writer.Write(WorksheetXml.StartWorksheet);
-
-            var yIndex = xy.Item2;
-
-            // dimension
-            var maxRowIndex = value.Rows.Count + (_printHeader && value.Rows.Count > 0 ? 1 : 0);
-            var maxColumnIndex = value.Columns.Count;
-            writer.Write(WorksheetXml.Dimension(GetDimensionRef(maxRowIndex, maxColumnIndex)));
-
-            var props = new List<ExcelColumnInfo>();
-            for (var i = 0; i < value.Columns.Count; i++)
-            {
-                var columnName = value.Columns[i].Caption ?? value.Columns[i].ColumnName;
-                var prop = GetColumnInfosFromDynamicConfiguration(columnName);
-                props.Add(prop);
-            }
-
-            //sheet view
-            writer.Write(GetSheetViews());
-
-            ExcelWidthCollection widths = null;
-            long columnWidthsPlaceholderPosition = 0;
-            if (_configuration.EnableAutoWidth)
-            {
-                columnWidthsPlaceholderPosition = WriteColumnWidthPlaceholders(writer, props);
-                widths = new ExcelWidthCollection(_configuration.MinWidth, _configuration.MaxWidth, props);
-            }
-            else
-            {
-                WriteColumnsWidths(writer, ExcelColumnWidth.FromProps(props));
-            }
-
-            writer.Write(WorksheetXml.StartSheetData);
-            if (_printHeader)
-            {
-                writer.Write(WorksheetXml.StartRow(yIndex));
-                var xIndex = xy.Item1;
-                foreach (var p in props)
-                {
-                    var r = ExcelOpenXmlUtils.ConvertXyToCell(xIndex, yIndex);
-                    WriteCell(writer, r, columnName: p.ExcelColumnName);
-                    xIndex++;
-                }
-
-                writer.Write(WorksheetXml.EndRow);
-                yIndex++;
-            }
-
-            for (int i = 0; i < value.Rows.Count; i++)
-            {
-                writer.Write(WorksheetXml.StartRow(yIndex));
-                var xIndex = xy.Item1;
-
-                for (int j = 0; j < value.Columns.Count; j++)
-                {
-                    var cellValue = value.Rows[i][j];
-                    WriteCell(writer, yIndex, xIndex, cellValue, columnInfo: props?.FirstOrDefault(x => x?.ExcelColumnIndex == xIndex - 1), widths);
-                    xIndex++;
-                }
-                writer.Write(WorksheetXml.EndRow);
-                yIndex++;
-            }
-
-            writer.Write(WorksheetXml.EndSheetData);
-
-            if (_configuration.AutoFilter)
-            {
-                writer.Write(WorksheetXml.Autofilter(GetDimensionRef(maxRowIndex, maxColumnIndex)));
-            }
-
-            if (_configuration.EnableAutoWidth)
-            {
-                OverWriteColumnWidthPlaceholders(writer, columnWidthsPlaceholderPosition, widths.Columns);
-            }
-
-            writer.Write(WorksheetXml.EndWorksheet);
-        }
 
         private long WriteColumnWidthPlaceholders(MiniExcelStreamWriter writer, ICollection<ExcelColumnInfo> props)
         {

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 
 namespace MiniExcelLibs.OpenXml

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -323,52 +323,6 @@ namespace MiniExcelLibs.OpenXml
             writer.Write(WorksheetXml.EndRow);
         }
 
-        private int GenerateSheetByColumnInfo<T>(MiniExcelStreamWriter writer, IEnumerator value, List<ExcelColumnInfo> props, ExcelWidthCollection widthCollection, int xIndex = 1, int yIndex = 1)
-        {
-            var isDic = typeof(T) == typeof(IDictionary);
-            var isDapperRow = typeof(T) == typeof(IDictionary<string, object>);
-            do
-            {
-                // The enumerator has already moved to the first item
-                T v = (T)value.Current;
-
-                writer.Write(WorksheetXml.StartRow(yIndex));
-                var cellIndex = xIndex;
-                foreach (var columnInfo in props)
-                {
-                    if (columnInfo == null) //reason:https://github.com/shps951023/MiniExcel/issues/142
-                    {
-                        cellIndex++;
-                        continue;
-                    }
-                    object cellValue = null;
-                    if (isDic)
-                    {
-                        cellValue = ((IDictionary)v)[columnInfo.Key];
-                        //WriteCell(writer, yIndex, cellIndex, cellValue, null); // why null because dictionary that needs to check type every time
-                        //TODO: user can specefic type to optimize efficiency
-                    }
-                    else if (isDapperRow)
-                    {
-                        cellValue = ((IDictionary<string, object>)v)[columnInfo.Key.ToString()];
-                    }
-                    else
-                    {
-                        cellValue = columnInfo.Property.GetValue(v);
-                    }
-
-                    WriteCell(writer, yIndex, cellIndex, cellValue, columnInfo, widthCollection);
-
-                    cellIndex++;
-                }
-
-                writer.Write(WorksheetXml.EndRow);
-                yIndex++;
-            } while (value.MoveNext());
-
-            return yIndex - 1;
-        }
-
         private void WriteCell(MiniExcelStreamWriter writer, int rowIndex, int cellIndex, object value, ExcelColumnInfo columnInfo, ExcelWidthCollection widthCollection)
         {
             var columnReference = ExcelOpenXmlUtils.ConvertXyToCell(cellIndex, rowIndex);

--- a/src/MiniExcel/Utils/TypeHelper.cs
+++ b/src/MiniExcel/Utils/TypeHelper.cs
@@ -161,5 +161,16 @@
             return newValue;
         }
 
+#if NETSTANDARD2_0_OR_GREATER || NET
+        public static bool IsAsyncEnumerable(this Type type, out Type genericArgument)
+        {
+            var asyncEnumrableInterfaceType = type
+                .GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>));
+            genericArgument = asyncEnumrableInterfaceType?.GetGenericArguments().FirstOrDefault();
+            return genericArgument != null;
+        }
+#endif
+
     }
 }

--- a/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
@@ -23,18 +23,23 @@ namespace MiniExcelLibs.WriteAdapter
 
         public async Task<List<ExcelColumnInfo>> GetColumnsAsync()
         {
-            if (CustomPropertyHelper.TryGetTypeColumnInfo(typeof(T), _configuration, out var props))
-            {
-                return props;
-            }
-
             _enumerator = _values.GetAsyncEnumerator();
             if (!await _enumerator.MoveNextAsync())
             {
-                _empty = true;
-                return new List<ExcelColumnInfo>();
+                if (CustomPropertyHelper.TryGetTypeColumnInfo(typeof(T), _configuration, out var props))
+                {
+                    return props;
+                }
+                else
+                {
+                    _empty = true;
+                    return null;
+                }
             }
-            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+            else
+            {
+                return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+            }
         }
 
         public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
@@ -23,23 +23,18 @@ namespace MiniExcelLibs.WriteAdapter
 
         public async Task<List<ExcelColumnInfo>> GetColumnsAsync()
         {
+            if (CustomPropertyHelper.TryGetTypeColumnInfo(typeof(T), _configuration, out var props))
+            {
+                return props;
+            }
+
             _enumerator = _values.GetAsyncEnumerator();
             if (!await _enumerator.MoveNextAsync())
             {
-                if (CustomPropertyHelper.TryGetTypeColumnInfo(typeof(T), _configuration, out var props))
-                {
-                    return props;
-                }
-                else
-                {
-                    _empty = true;
-                    return null;
-                }
+                _empty = true;
+                return null;
             }
-            else
-            {
-                return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
-            }
+            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
         }
 
         public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props, [EnumeratorCancellation] CancellationToken cancellationToken)

--- a/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
@@ -1,6 +1,8 @@
 ﻿using MiniExcelLibs.Utils;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 #if NETSTANDARD2_0_OR_GREATER || NET
@@ -35,7 +37,7 @@ namespace MiniExcelLibs.WriteAdapter
             return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
         }
 
-        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props)
+        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             if (_empty)
             {
@@ -53,6 +55,7 @@ namespace MiniExcelLibs.WriteAdapter
 
             do
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return GetRowValuesAsync(_enumerator.Current, props);
 
             } while (await _enumerator.MoveNextAsync());

--- a/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/AsyncEnumerableWriteAdapter.cs
@@ -1,0 +1,92 @@
+﻿using MiniExcelLibs.Utils;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_0_OR_GREATER || NET
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal class AsyncEnumerableWriteAdapter<T> : IAsyncMiniExcelWriteAdapter
+    {
+        private readonly IAsyncEnumerable<T> _values;
+        private readonly Configuration _configuration;
+        private IAsyncEnumerator<T> _enumerator;
+        private bool _empty;
+
+        public AsyncEnumerableWriteAdapter(IAsyncEnumerable<T> values, Configuration configuration)
+        {
+            _values = values;
+            _configuration = configuration;
+        }
+
+        public async Task<List<ExcelColumnInfo>> GetColumnsAsync()
+        {
+            if (CustomPropertyHelper.TryGetTypeColumnInfo(typeof(T), _configuration, out var props))
+            {
+                return props;
+            }
+
+            _enumerator = _values.GetAsyncEnumerator();
+            if (!await _enumerator.MoveNextAsync())
+            {
+                _empty = true;
+                return new List<ExcelColumnInfo>();
+            }
+            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+        }
+
+        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props)
+        {
+            if (_empty)
+            {
+                yield break;
+            }
+
+            if (_enumerator is null)
+            {
+                _enumerator = _values.GetAsyncEnumerator();
+                if (!await _enumerator.MoveNextAsync())
+                {
+                    yield break;
+                }
+            }
+
+            do
+            {
+                yield return GetRowValuesAsync(_enumerator.Current, props);
+
+            } while (await _enumerator.MoveNextAsync());
+        }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public async static IAsyncEnumerable<CellWriteInfo> GetRowValuesAsync(T currentValue, List<ExcelColumnInfo> props)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            var column = 1;
+            foreach (var prop in props)
+            {
+                if (prop == null)
+                {
+                    column++;
+                    continue;
+                }
+
+                switch (currentValue)
+                {
+                    case IDictionary<string, object> genericDictionary:
+                        yield return new CellWriteInfo(genericDictionary[prop.Key.ToString()], column, prop);
+                        break;
+                    case IDictionary dictionary:
+                        yield return new CellWriteInfo(dictionary[prop.Key], column, prop);
+                        break;
+                    default:
+                        yield return new CellWriteInfo(prop.Property.GetValue(currentValue), column, prop);
+                        break;
+                }
+
+                column++;
+            }
+        }
+    }
+}
+#endif

--- a/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Threading;
 
 namespace MiniExcelLibs.WriteAdapter
 {
@@ -52,10 +53,11 @@ namespace MiniExcelLibs.WriteAdapter
             return props;
         }
 
-        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default)
         {
             while (_reader.Read())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return GetRowValues(props);
             }
         }

--- a/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
@@ -1,0 +1,81 @@
+﻿using MiniExcelLibs.Utils;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal class DataReaderWriteAdapter : IMiniExcelWriteAdapter
+    {
+        private readonly IDataReader _reader;
+        private readonly Configuration _configuration;
+
+        public DataReaderWriteAdapter(IDataReader reader, Configuration configuration)
+        {
+            _reader = reader;
+            _configuration = configuration;
+        }
+
+        public bool TryGetNonEnumeratedCount(out int count)
+        {
+            count = 0;
+            return false;
+        }
+
+        public List<ExcelColumnInfo> GetColumns()
+        {
+            var props = new List<ExcelColumnInfo>();
+            for (var i = 0; i < _reader.FieldCount; i++)
+            {
+                var columnName = _reader.GetName(i);
+
+                if (!_configuration.DynamicColumnFirst)
+                {
+                    var prop = CustomPropertyHelper.GetColumnInfosFromDynamicConfiguration(columnName, _configuration);
+                    props.Add(prop);
+                    continue;
+                }
+
+                if (_configuration
+                    .DynamicColumns
+                    .Any(a => string.Equals(
+                        a.Key,
+                        columnName,
+                        StringComparison.OrdinalIgnoreCase)))
+
+                {
+                    var prop = CustomPropertyHelper.GetColumnInfosFromDynamicConfiguration(columnName, _configuration);
+                    props.Add(prop);
+                }
+            }
+            return props;
+        }
+
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        {
+            while (_reader.Read())
+            {
+                yield return GetRowValues(props);
+            }
+        }
+
+        private IEnumerable<CellWriteInfo> GetRowValues(List<ExcelColumnInfo> props)
+        {
+            for (int i = 0, column = 1; i < _reader.FieldCount; i++, column++)
+            {
+                if (_configuration.DynamicColumnFirst)
+                {
+                    var columnIndex = _reader.GetOrdinal(props[i].Key.ToString());
+                    yield return new CellWriteInfo(_reader.GetValue(columnIndex), column, props[i]);
+                }
+                else
+                {
+                    yield return new CellWriteInfo(_reader.GetValue(i), column, props[i]);
+                }
+            }
+        }
+    }
+}
+
+

--- a/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataReaderWriteAdapter.cs
@@ -18,7 +18,7 @@ namespace MiniExcelLibs.WriteAdapter
             _configuration = configuration;
         }
 
-        public bool TryGetNonEnumeratedCount(out int count)
+        public bool TryGetKnownCount(out int count)
         {
             count = 0;
             return false;

--- a/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
@@ -16,7 +16,7 @@ namespace MiniExcelLibs.WriteAdapter
             _configuration = configuration;
         }
 
-        public bool TryGetNonEnumeratedCount(out int count)
+        public bool TryGetKnownCount(out int count)
         {
             count = _dataTable.Rows.Count;
             return true;

--- a/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
@@ -1,6 +1,7 @@
 ﻿using MiniExcelLibs.Utils;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 
 namespace MiniExcelLibs.WriteAdapter
 {
@@ -33,10 +34,11 @@ namespace MiniExcelLibs.WriteAdapter
             return props;
         }
 
-        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default)
         {
             for (int row = 0; row < _dataTable.Rows.Count; row++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return GetRowValues(row, props);
             }
         }

--- a/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/DataTableWriteAdapter.cs
@@ -1,0 +1,54 @@
+﻿using MiniExcelLibs.Utils;
+using System.Collections.Generic;
+using System.Data;
+
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal class DataTableWriteAdapter : IMiniExcelWriteAdapter
+    {
+        private readonly DataTable _dataTable;
+        private readonly Configuration _configuration;
+
+        public DataTableWriteAdapter(DataTable dataTable, Configuration configuration)
+        {
+            _dataTable = dataTable;
+            _configuration = configuration;
+        }
+
+        public bool TryGetNonEnumeratedCount(out int count)
+        {
+            count = _dataTable.Rows.Count;
+            return true;
+        }
+
+        public List<ExcelColumnInfo> GetColumns()
+        {
+            var props = new List<ExcelColumnInfo>();
+            for (var i = 0; i < _dataTable.Columns.Count; i++)
+            {
+                var columnName = _dataTable.Columns[i].Caption ?? _dataTable.Columns[i].ColumnName;
+                var prop = CustomPropertyHelper.GetColumnInfosFromDynamicConfiguration(columnName, _configuration);
+                props.Add(prop);
+            }
+            return props;
+        }
+
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        {
+            for (int row = 0; row < _dataTable.Rows.Count; row++)
+            {
+                yield return GetRowValues(row, props);
+            }
+        }
+
+        private IEnumerable<CellWriteInfo> GetRowValues(int row, List<ExcelColumnInfo> props)
+        {
+            for (int i = 0, column = 1; i < _dataTable.Columns.Count; i++, column++)
+            {
+                yield return new CellWriteInfo(_dataTable.Rows[row][i], column, props[i]);
+            }
+        }
+    }
+}
+
+

--- a/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
@@ -37,23 +37,18 @@ namespace MiniExcelLibs.WriteAdapter
 
         public List<ExcelColumnInfo> GetColumns()
         {
+            if (CustomPropertyHelper.TryGetTypeColumnInfo(_genericType, _configuration, out var props))
+            {
+                return props;
+            }
+
             _enumerator = _values.GetEnumerator();
             if (!_enumerator.MoveNext())
             {
-                if (CustomPropertyHelper.TryGetTypeColumnInfo(_genericType, _configuration, out var props))
-                {
-                    return props;
-                }
-                else
-                {
-                    _empty = true;
-                    return null;
-                }
+                _empty = true;
+                return null;
             }
-            else
-            {
-                return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
-            }
+            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);           
         }
 
         public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default)

--- a/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
@@ -23,7 +23,7 @@ namespace MiniExcelLibs.WriteAdapter
             _genericType = TypeHelper.GetGenericIEnumerables(values).FirstOrDefault();
         }
 
-        public bool TryGetNonEnumeratedCount(out int count)
+        public bool TryGetKnownCount(out int count)
         {
             count = 0;
             if (_values is ICollection collection)
@@ -37,18 +37,23 @@ namespace MiniExcelLibs.WriteAdapter
 
         public List<ExcelColumnInfo> GetColumns()
         {
-            if (CustomPropertyHelper.TryGetTypeColumnInfo(_genericType, _configuration, out var props))
-            {
-                return props;
-            }
-
             _enumerator = _values.GetEnumerator();
             if (!_enumerator.MoveNext())
             {
-                _empty = true;
-                return new List<ExcelColumnInfo>();
+                if (CustomPropertyHelper.TryGetTypeColumnInfo(_genericType, _configuration, out var props))
+                {
+                    return props;
+                }
+                else
+                {
+                    _empty = true;
+                    return null;
+                }
             }
-            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+            else
+            {
+                return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+            }
         }
 
         public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default)

--- a/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
@@ -1,0 +1,103 @@
+﻿using MiniExcelLibs.Utils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal class EnumerableWriteAdapter : IMiniExcelWriteAdapter
+    {
+        private readonly IEnumerable _values;
+        private readonly Configuration _configuration;
+        private readonly Type _genericType;
+
+        private IEnumerator _enumerator;
+        private bool _empty;
+
+        public EnumerableWriteAdapter(IEnumerable values, Configuration configuration)
+        {
+            _values = values;
+            _configuration = configuration;
+            _genericType = TypeHelper.GetGenericIEnumerables(values).FirstOrDefault();
+        }
+
+        public bool TryGetNonEnumeratedCount(out int count)
+        {
+            count = 0;
+            if (_values is ICollection collection)
+            {
+                count = collection.Count;
+                return true;
+            }
+
+            return false;
+        }
+
+        public List<ExcelColumnInfo> GetColumns()
+        {
+            if (CustomPropertyHelper.TryGetTypeColumnInfo(_genericType, _configuration, out var props))
+            {
+                return props;
+            }
+
+            _enumerator = _values.GetEnumerator();
+            if (!_enumerator.MoveNext())
+            {
+                _empty = true;
+                return new List<ExcelColumnInfo>();
+            }
+            return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
+        }
+
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        {
+            if (_empty)
+            {
+                yield break;
+            }
+
+            if (_enumerator is null)
+            {
+                _enumerator = _values.GetEnumerator();
+                if (!_enumerator.MoveNext())
+                {
+                    yield break;
+                }
+            }
+
+            do
+            {
+                yield return GetRowValues(_enumerator.Current, props);
+            } while (_enumerator.MoveNext());
+        }
+
+
+        public static IEnumerable<CellWriteInfo> GetRowValues(object currentValue, List<ExcelColumnInfo> props)
+        {
+            var column = 1;
+            foreach (var prop in props)
+            {
+                object cellValue;
+                if (prop == null)
+                {
+                    cellValue = null;
+                }
+                else if (currentValue is IDictionary<string, object> genericDictionary)
+                {
+                    cellValue = genericDictionary[prop.Key.ToString()];
+                }
+                else if (currentValue is IDictionary dictionary)
+                {
+                    cellValue = dictionary[prop.Key];
+                }
+                else 
+                {
+                    cellValue = prop.Property.GetValue(currentValue);
+                }
+                yield return new CellWriteInfo(cellValue, column, prop);
+                column++;
+            }
+        }
+    }
+}

--- a/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/EnumerableWriteAdapter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace MiniExcelLibs.WriteAdapter
 {
@@ -50,7 +51,7 @@ namespace MiniExcelLibs.WriteAdapter
             return CustomPropertyHelper.GetColumnInfoFromValue(_enumerator.Current, _configuration);
         }
 
-        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props)
+        public IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default)
         {
             if (_empty)
             {
@@ -68,6 +69,7 @@ namespace MiniExcelLibs.WriteAdapter
 
             do
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return GetRowValues(_enumerator.Current, props);
             } while (_enumerator.MoveNext());
         }

--- a/src/MiniExcel/WriteAdapter/IAsyncMiniExcelWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/IAsyncMiniExcelWriteAdapter.cs
@@ -1,0 +1,15 @@
+﻿using MiniExcelLibs.Utils;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_0_OR_GREATER || NET
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal interface IAsyncMiniExcelWriteAdapter 
+    {
+        Task<List<ExcelColumnInfo>> GetColumnsAsync();
+
+        IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props);
+    }
+}
+#endif

--- a/src/MiniExcel/WriteAdapter/IAsyncMiniExcelWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/IAsyncMiniExcelWriteAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using MiniExcelLibs.Utils;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 #if NETSTANDARD2_0_OR_GREATER || NET
@@ -9,7 +10,7 @@ namespace MiniExcelLibs.WriteAdapter
     {
         Task<List<ExcelColumnInfo>> GetColumnsAsync();
 
-        IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props);
+        IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props, CancellationToken cancellationToken);
     }
 }
 #endif

--- a/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
@@ -1,0 +1,30 @@
+﻿using MiniExcelLibs.Utils;
+using System.Collections.Generic;
+
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal interface IMiniExcelWriteAdapter
+    {
+        bool TryGetNonEnumeratedCount(out int count);
+
+        List<ExcelColumnInfo> GetColumns();
+
+        IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props);
+    }
+
+    internal readonly struct CellWriteInfo
+    {
+        public CellWriteInfo(object value, int cellIndex, ExcelColumnInfo prop)
+        {
+            Value = value;
+            CellIndex = cellIndex;
+            Prop = prop;
+        }
+
+        public object Value { get; }
+        public int CellIndex { get; }
+        public ExcelColumnInfo Prop { get; }
+    }
+}
+
+

--- a/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using MiniExcelLibs.Utils;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace MiniExcelLibs.WriteAdapter
 {
@@ -9,7 +10,7 @@ namespace MiniExcelLibs.WriteAdapter
 
         List<ExcelColumnInfo> GetColumns();
 
-        IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props);
+        IEnumerable<IEnumerable<CellWriteInfo>> GetRows(List<ExcelColumnInfo> props, CancellationToken cancellationToken = default);
     }
 
     internal readonly struct CellWriteInfo

--- a/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/IMiniExcelWriteAdapter.cs
@@ -6,7 +6,7 @@ namespace MiniExcelLibs.WriteAdapter
 {
     internal interface IMiniExcelWriteAdapter
     {
-        bool TryGetNonEnumeratedCount(out int count);
+        bool TryGetKnownCount(out int count);
 
         List<ExcelColumnInfo> GetColumns();
 

--- a/src/MiniExcel/WriteAdapter/MiniExcelDataReaderWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/MiniExcelDataReaderWriteAdapter.cs
@@ -1,0 +1,75 @@
+﻿using MiniExcelLibs.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_0_OR_GREATER || NET
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal class MiniExcelDataReaderWriteAdapter : IAsyncMiniExcelWriteAdapter
+    {
+        private readonly IMiniExcelDataReader _reader;
+        private readonly Configuration _configuration;
+
+        public MiniExcelDataReaderWriteAdapter(IMiniExcelDataReader reader, Configuration configuration)
+        {
+            _reader = reader;
+            _configuration = configuration;
+        }
+
+        public async Task<List<ExcelColumnInfo>> GetColumnsAsync()
+        {
+            var props = new List<ExcelColumnInfo>();
+            for (var i = 0; i < _reader.FieldCount; i++)
+            {
+                var columnName = await _reader.GetNameAsync(i);
+
+                if (!_configuration.DynamicColumnFirst)
+                {
+                    var prop = CustomPropertyHelper.GetColumnInfosFromDynamicConfiguration(columnName, _configuration);
+                    props.Add(prop);
+                    continue;
+                }
+
+                if (_configuration
+                    .DynamicColumns
+                    .Any(a => string.Equals(
+                        a.Key,
+                        columnName,
+                        StringComparison.OrdinalIgnoreCase)))
+
+                {
+                    var prop = CustomPropertyHelper.GetColumnInfosFromDynamicConfiguration(columnName, _configuration);
+                    props.Add(prop);
+                }
+            }
+            return props;
+        }
+
+        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props)
+        {
+            while (await _reader.ReadAsync())
+            {
+                yield return GetRowValuesAsync(props);
+            }
+        }
+
+        private async IAsyncEnumerable<CellWriteInfo> GetRowValuesAsync(List<ExcelColumnInfo> props)
+        {
+            for (int i = 0, column = 1; i < _reader.FieldCount; i++, column++)
+            {
+                if (_configuration.DynamicColumnFirst)
+                {
+                    var columnIndex = _reader.GetOrdinal(props[i].Key.ToString());
+                    yield return new CellWriteInfo(await _reader.GetValueAsync(columnIndex), column, props[i]);
+                }
+                else
+                {
+                    yield return new CellWriteInfo(await _reader.GetValueAsync(i), column, props[i]);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/MiniExcel/WriteAdapter/MiniExcelDataReaderWriteAdapter.cs
+++ b/src/MiniExcel/WriteAdapter/MiniExcelDataReaderWriteAdapter.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 #if NETSTANDARD2_0_OR_GREATER || NET
@@ -47,10 +49,11 @@ namespace MiniExcelLibs.WriteAdapter
             return props;
         }
 
-        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props)
+        public async IAsyncEnumerable<IAsyncEnumerable<CellWriteInfo>> GetRowsAsync(List<ExcelColumnInfo> props, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             while (await _reader.ReadAsync())
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 yield return GetRowValuesAsync(props);
             }
         }

--- a/src/MiniExcel/WriteAdapter/MiniExcelWriteAdapterFactory.cs
+++ b/src/MiniExcel/WriteAdapter/MiniExcelWriteAdapterFactory.cs
@@ -1,0 +1,45 @@
+﻿using MiniExcelLibs.Utils;
+using System;
+using System.Collections;
+using System.Data;
+
+namespace MiniExcelLibs.WriteAdapter
+{
+    internal static class MiniExcelWriteAdapterFactory
+    {
+#if NETSTANDARD2_0_OR_GREATER || NET
+        public static bool TryGetAsyncWriteAdapter(object values, Configuration configuration, out IAsyncMiniExcelWriteAdapter writeAdapter)
+        {
+            writeAdapter = null;
+            if (values.GetType().IsAsyncEnumerable(out var genericArgument))
+            {
+                var writeAdapterType = typeof(AsyncEnumerableWriteAdapter<>).MakeGenericType(genericArgument);
+                writeAdapter = (IAsyncMiniExcelWriteAdapter)Activator.CreateInstance(writeAdapterType, values, configuration);
+                return true;
+            }
+            if (values is IMiniExcelDataReader miniExcelDataReader)
+            {
+                writeAdapter = new MiniExcelDataReaderWriteAdapter(miniExcelDataReader, configuration);
+                return true;
+            }
+
+            return false;
+        }
+#endif
+
+        public static IMiniExcelWriteAdapter GetWriteAdapter(object values, Configuration configuration)
+        {
+            switch (values)
+            {
+                case IDataReader dataReader:
+                    return new DataReaderWriteAdapter(dataReader, configuration);
+                case IEnumerable enumerable:
+                    return new EnumerableWriteAdapter(enumerable, configuration);
+                case DataTable dataTable:
+                    return new DataTableWriteAdapter(dataTable, configuration);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/tests/MiniExcelTests/MiniExcelCsvAsycTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvAsycTests.cs
@@ -59,9 +59,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
                 var table = new Dictionary<string, object>(); //TODO
-                await MiniExcel.SaveAsAsync(path, table);
-                //Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
-                Assert.Equal("\r\n", File.ReadAllText(path));
+                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
                 File.Delete(path);
             }
 
@@ -316,6 +314,33 @@ namespace MiniExcelLibs.Tests
                 Assert.Null(rows[1].c1);
                 Assert.Null(rows[1].c2);
             }
+
+            File.Delete(path);
+        }
+
+        [Fact]
+        public async Task SaveAsByAsyncEnumerable()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            static async IAsyncEnumerable<Test> GetValues()
+            {
+                yield return new Test { c1 = "A1", c2 = "B1" };
+                yield return new Test { c1 = "A2", c2 = "B2" };
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+
+            await MiniExcel.SaveAsAsync(path, GetValues());
+
+            var results = MiniExcel.Query<Test>(path);
+
+            Assert.True(results.Count() == 2);
+            Assert.True(results.First().c1 == "A1");
+            Assert.True(results.First().c2 == "B1");
+            Assert.True(results.Last().c1 == "A2");
+            Assert.True(results.Last().c2 == "B2");
 
             File.Delete(path);
         }

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -89,9 +89,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
                 var table = new Dictionary<string, object>(); //TODO
-                MiniExcel.SaveAs(path, table);
-                //Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
-                Assert.Equal("\r\n", File.ReadAllText(path));
+                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
                 File.Delete(path);
             }
 

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -626,21 +626,11 @@ namespace MiniExcelLibs.Tests
                 var table = new DataTable();
                 await MiniExcel.SaveAsAsync(path, table);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
-                {
-                    using (var stream = File.OpenRead(path))
-                    {
-                        var d = await stream.QueryAsync();
-                        var rows = d.ToList();
-                        Assert.Single(rows); //TODO:
-                    }
-                    File.Delete(path);
-                }
-
+                File.Delete(path);
                 await MiniExcel.SaveAsAsync(path, table, printHeader: false);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
                 File.Delete(path);
             }
-
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
                 var table = new DataTable();

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -626,7 +626,15 @@ namespace MiniExcelLibs.Tests
                 var table = new DataTable();
                 await MiniExcel.SaveAsAsync(path, table);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
-                File.Delete(path);
+                {
+                    using (var stream = File.OpenRead(path))
+                    {
+                        var d = await stream.QueryAsync();
+                        var rows = d.ToList();
+                        Assert.Single(rows); //TODO:
+                    }
+                    File.Delete(path);
+                }
                 await MiniExcel.SaveAsAsync(path, table, printHeader: false);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
                 File.Delete(path);

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -1685,5 +1685,32 @@ namespace MiniExcelLibs.Tests
 ", content);
             }
         }
+
+        [Fact]
+        public async Task SaveAsByAsyncEnumerable()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            static async IAsyncEnumerable<Demo> GetValues()
+            {
+                yield return new Demo { Column1 = "MiniExcel", Column2 = 1 };
+                yield return new Demo { Column1 = "Github", Column2 = 2 };
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+
+            await MiniExcel.SaveAsAsync(path, GetValues());
+
+            var results = MiniExcel.Query<Demo>(path);
+
+            Assert.True(results.Count() == 2);
+            Assert.True(results.First().Column1 == "MiniExcel");
+            Assert.True(results.First().Column2 == 1);
+            Assert.True(results.Last().Column1 == "Github");
+            Assert.True(results.Last().Column2 == 2);
+
+            File.Delete(path);
+        }
     }
 }

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -622,14 +622,7 @@ namespace MiniExcelLibs.Tests
                 var table = new DataTable();
                 MiniExcel.SaveAs(path, table);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
-                {
-                    using (var stream = File.OpenRead(path))
-                    {
-                        var rows = stream.Query().ToList();
-                        Assert.Single(rows); //TODO:
-                    }
-                    File.Delete(path);
-                }
+                File.Delete(path);
 
                 MiniExcel.SaveAs(path, table, printHeader: false);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -622,7 +622,14 @@ namespace MiniExcelLibs.Tests
                 var table = new DataTable();
                 MiniExcel.SaveAs(path, table);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
-                File.Delete(path);
+                {
+                    using (var stream = File.OpenRead(path))
+                    {
+                        var rows = stream.Query().ToList();
+                        Assert.Single(rows); //TODO:
+                    }
+                    File.Delete(path);
+                }
 
                 MiniExcel.SaveAs(path, table, printHeader: false);
                 Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));


### PR DESCRIPTION
I have done some work previously with the writing logic in MiniExcel and I always found it cumbersome to duplicate it across different datasource implementations .

This PR adds two new interfaces `IMiniExcelWriteAdapter` and `IAsyncMiniExcelWriteAdapter` to generalize data fetching for writing to excel or csv. Which makes is much easier to add support for new datasources as well as adding new functionality or fixing bugs.

I also added support for writing `IAsyncEnumerable` to both excel and csv. 

#706 added support for writing asynchronously with the `IMiniExcelDataReader`. I moved this implementation into `MiniExcelDataReaderWriteAdapter` which uses `IAsyncEnumerable` internally. This makes it incompatible with dotnet 4.5.  @izanhzh

Another change which might be breaking is that writing an empty collection will no longer produce 1 row, but 0.