### PR TITLE
feat(DynamicExcelColumn): make the CustomFormatter property more powerful

### DIFF
--- a/src/MiniExcel/Attributes/ExcelColumnAttribute.cs
+++ b/src/MiniExcel/Attributes/ExcelColumnAttribute.cs
@@ -58,7 +58,7 @@ namespace MiniExcelLibs.Attributes
     {
         public string Key { get; set; }
         
-        public Func<object, string> CustomFormatter { get; set; }
+        public Func<object, object> CustomFormatter { get; set; }
 
         public DynamicExcelColumn(string key)
         {

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.Async.cs
@@ -334,6 +334,18 @@ namespace MiniExcelLibs.OpenXml
                 return;
             }
 
+            if (p.CustomFormatter != null)
+            {
+                try
+                {
+                    value = p.CustomFormatter(value);
+                }
+                catch
+                {
+                    //ignored
+                }
+            }
+
             var tuple = GetCellValue(rowIndex, cellIndex, value, p, valueIsNull);
 
             var styleIndex = tuple.Item1;
@@ -344,18 +356,6 @@ namespace MiniExcelLibs.OpenXml
             /*Prefix and suffix blank space will lost after SaveAs #294*/
             var preserveSpace = cellValue != null && (cellValue.StartsWith(" ", StringComparison.Ordinal) ||
                                                       cellValue.EndsWith(" ", StringComparison.Ordinal));
-
-            if (p.CustomFormatter != null)
-            {
-                try
-                {
-                    cellValue = p.CustomFormatter(cellValue);
-                }
-                catch
-                {
-                    //ignored
-                }
-            }
 
             await writer.WriteAsync(WorksheetXml.Cell(columnReference, dataType, GetCellXfId(styleIndex), cellValue, preserveSpace: preserveSpace, columnType: columnType));
             widthCollection?.AdjustWidth(cellIndex, cellValue);

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -334,23 +334,23 @@ namespace MiniExcelLibs.OpenXml
                 return;
             }
 
-            var tuple = GetCellValue(rowIndex, cellIndex, value, columnInfo, valueIsNull);
-
-            var styleIndex = tuple.Item1; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-3.0.1
-            var dataType = tuple.Item2; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cellvalues?view=openxml-3.0.1
-            var cellValue = tuple.Item3;
-
             if (columnInfo?.CustomFormatter != null)
             {
                 try
                 {
-                    cellValue = columnInfo.CustomFormatter(cellValue);
+                    value = columnInfo.CustomFormatter(value);
                 }
                 catch
                 {
                     //ignored
                 }
             }
+
+            var tuple = GetCellValue(rowIndex, cellIndex, value, columnInfo, valueIsNull);
+
+            var styleIndex = tuple.Item1; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-3.0.1
+            var dataType = tuple.Item2; // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cellvalues?view=openxml-3.0.1
+            var cellValue = tuple.Item3;
 
             var columnType = columnInfo?.ExcelColumnType ?? ColumnType.Value;
 

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -25,7 +25,7 @@
         public bool ExcelIgnore { get; internal set; }
         public int ExcelFormatId { get; internal set; }
         public ColumnType ExcelColumnType { get; internal set; }
-        public Func<object, string> CustomFormatter { get; set; }
+        public Func<object, object> CustomFormatter { get; set; }
     }
 
     internal class ExcellSheetInfo

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -183,12 +183,9 @@
                 var excludeNullableType = gt ?? p.PropertyType;
                 var excelFormat = p.GetAttribute<ExcelFormatAttribute>()?.Format;
                 var excelColumn = p.GetAttribute<ExcelColumnAttribute>();
-                if (configuration.DynamicColumns != null && configuration.DynamicColumns.Length > 0)
-                {
-                    var dynamicColumn = configuration.DynamicColumns.SingleOrDefault(_ => _.Key == p.Name);
-                    if (dynamicColumn != null)
-                        excelColumn = dynamicColumn;
-                }
+                var dynamicColumn = configuration?.DynamicColumns?.SingleOrDefault(_ => _.Key == p.Name);
+                if (dynamicColumn != null)
+                    excelColumn = dynamicColumn;
 
                 var ignore = p.GetAttributeValue((ExcelIgnoreAttribute x) => x.ExcelIgnore) || p.GetAttributeValue((ExcelColumnAttribute x) => x.Ignore) || (excelColumn != null && excelColumn.Ignore);
                 if (ignore)
@@ -209,7 +206,8 @@
                     ExcelColumnWidth = p.GetAttribute<ExcelColumnWidthAttribute>()?.ExcelColumnWidth ?? excelColumn?.Width,
                     ExcelFormat = excelFormat ?? excelColumn?.Format,
                     ExcelFormatId = excelColumn?.FormatId ?? -1,
-                    ExcelColumnType = excelColumn?.Type ?? ColumnType.Value
+                    ExcelColumnType = excelColumn?.Type ?? ColumnType.Value,
+                    CustomFormatter = dynamicColumn?.CustomFormatter
                 };
             }).Where(_ => _ != null);
         }


### PR DESCRIPTION
close: #708 

我注意到，在此前的PR #700 中，DynamicExcelColumn增加了一个属性：
```csharp
public Func<object, string> CustomFormatter { get; set; }
```
PR #700 存在一些问题，假设我原来的值是数字类型，因为这里返回的值是string类型，并且因为调用CustomFormatter委托时机问题，导致最终生成的Excel单元格设置是数字但实际值非数字，Excel打开报错，例如，我想对金额加一个币别符号1 -> $1

我进行了一些优化，调整为 `Func<object, object>`，可以避免此问题



