### PR TITLE
Fix @group tag not working with certain IEnumerable types

### DIFF
--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -976,7 +976,7 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
                         }
 
                         var cellValue = inputMaps[propNames[0]]; // 1. From left to right, only the first set is used as the basis for the list
-                        if ((cellValue is IEnumerable || cellValue is IList<object>) && !(cellValue is string))
+                        if (cellValue is IEnumerable && !(cellValue is string))
                         {
                             if (this.XMergeCellInfos.ContainsKey(r))
                             {
@@ -987,7 +987,9 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
                             }
 
                             xRowInfo.CellIEnumerableValues = cellValue as IEnumerable;
-                            xRowInfo.CellIlListValues = cellValue as IList<object>;
+                            xRowInfo.CellIlListValues = cellValue is IList<object> ?
+                                    cellValue as IList<object> :
+                                    xRowInfo.CellIEnumerableValues.Cast<object>().ToList();
 
                             // get ienumerable runtime type
                             if (xRowInfo.IEnumerableGenricType == null) //avoid duplicate to add rowindexdiff ![image](https://user-images.githubusercontent.com/12729184/114851348-522ac000-9e14-11eb-8244-4730754d6885.png)

--- a/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateTests.cs
+++ b/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateTests.cs
@@ -294,6 +294,66 @@ namespace MiniExcelTests.SaveByTemplate
             }
         }
 
+        private struct Employee
+        {
+            public string name { get; set; }
+            public string department { get; set; }
+        };
+
+        [Fact]
+        public void GroupTemplateTest()
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid().ToString()}.xlsx");
+            var templatePath = @"../../../../../samples/xlsx/TestTemplateBasicIEmumerableFillGroup.xlsx";
+            var value = new
+            {
+                employees = new List<Employee>()
+                {
+                    new(){ name = "Jack", department="HR" },
+                    new(){ name = "Jack", department="IT" },
+                    new(){ name = "Loan", department="IT" },
+                    new(){ name = "Eric", department="IT" },
+                    new(){ name = "Eric", department="HR" },
+                    new(){ name = "Keaton", department="IT" },
+                    new(){ name = "Felix", department="HR" },
+                },
+            };
+            MiniExcel.SaveAsByTemplate(path, templatePath, value);
+
+            {
+                var rows = MiniExcel.Query(path).ToList();
+
+                Assert.Equal(16, rows.Count);
+
+                Assert.Equal("Jack", rows[1].A);
+                Assert.Equal("Jack", rows[2].A);
+                Assert.Equal("HR", rows[2].B);
+                Assert.Equal("Jack", rows[3].A);
+                Assert.Equal("IT", rows[3].B);
+
+                Assert.Equal("Loan", rows[4].A);
+                Assert.Equal("Loan", rows[5].A);
+                Assert.Equal("IT", rows[5].B);
+
+                Assert.Equal("Eric", rows[6].A);
+                Assert.Equal("Eric", rows[7].A);
+                Assert.Equal("IT", rows[7].B);
+                Assert.Equal("Eric", rows[8].A);
+                Assert.Equal("HR", rows[8].B);
+
+                Assert.Equal("Keaton", rows[9].A);
+                Assert.Equal("Keaton", rows[10].A);
+                Assert.Equal("IT", rows[10].B);
+
+                Assert.Equal("Felix", rows[11].A);
+                Assert.Equal("Felix", rows[12].A);
+                Assert.Equal("HR", rows[12].B);
+
+                var demension = Helpers.GetFirstSheetDimensionRefValue(path);
+                Assert.Equal("A1:B20", demension);
+            }
+        }
+
         [Fact]
         public void TestGithubProject()
         {


### PR DESCRIPTION
If the IEnumerable type can't be casted to an IList<object>, such as a List of structs, xRowInfo.CellIlListValues will silently be NULL. To fix, I check if it can be casted to IList<object> first, then create one from CellIEnumerableValues if it can't. Later in generating a template, this issue would have caused a NullReferenceException when parsing the @endgroup tag.

Removed a redundent check for `cellValue is IList<object>`, because all IList types are IEnumerable.

Added a test for groups that would trigger a NullReferenceException before this patch.