### PR TITLE
Made some small optimizations to Dictionaries and Enumerables

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -322,12 +322,11 @@ namespace MiniExcelLibs.OpenXml
                                                 {
                                                     _mergeCells.MergesValues[aR] = cellValue;
                                                 }
-                                                else if (_mergeCells.MergesMap.ContainsKey(aR))
+                                                else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
                                                 {
-                                                    var mergeKey = _mergeCells.MergesMap[aR];
                                                     object mergeValue = null;
-                                                    if (_mergeCells.MergesValues.ContainsKey(mergeKey))
-                                                        mergeValue = _mergeCells.MergesValues[mergeKey];
+                                                    if (_mergeCells.MergesValues.TryGetValue(mergeKey, out var value))
+                                                        mergeValue = value;
                                                     cellValue = mergeValue;
                                                 }
                                             }
@@ -398,9 +397,8 @@ namespace MiniExcelLibs.OpenXml
                 }
                 else
                 {
-                    if (headRows.ContainsKey(columnIndex))
+                    if (headRows.TryGetValue(columnIndex, out var key))
                     {
-                        var key = headRows[columnIndex];
                         cell[key] = cellValue;
                     }
                 }
@@ -467,10 +465,9 @@ namespace MiniExcelLibs.OpenXml
                     {
                         foreach (var alias in pInfo.ExcelColumnAliases)
                         {
-                            if (headersDic.ContainsKey(alias))
+                            if (headersDic.TryGetValue(alias, out var columnId))
                             {
                                 object newV = null;
-                                var columnId = headersDic[alias];
                                 var columnName = keys[columnId];
                                 item.TryGetValue(columnName, out var itemValue);
 
@@ -490,9 +487,8 @@ namespace MiniExcelLibs.OpenXml
                         {
                             item.TryGetValue(pInfo.ExcelIndexName, out itemValue);
                         }
-                        else if (headersDic.ContainsKey(pInfo.ExcelColumnName))
+                        else if (headersDic.TryGetValue(pInfo.ExcelColumnName, out var columnId))
                         {
-                            var columnId = headersDic[pInfo.ExcelColumnName];
                             var columnName = keys[columnId];
                             item.TryGetValue(columnName, out itemValue);
                         }
@@ -1086,13 +1082,9 @@ namespace MiniExcelLibs.OpenXml
                                                 {
                                                     _mergeCells.MergesValues[aR] = cellValue;
                                                 }
-                                                else if (_mergeCells.MergesMap.ContainsKey(aR))
+                                                else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
                                                 {
-                                                    var mergeKey = _mergeCells.MergesMap[aR];
-                                                    object mergeValue = null;
-                                                    if (_mergeCells.MergesValues.ContainsKey(mergeKey))
-                                                        mergeValue = _mergeCells.MergesValues[mergeKey];
-                                                    cellValue = mergeValue;
+                                                    _mergeCells.MergesValues.TryGetValue(mergeKey, out cellValue);
                                                 }
                                             }
                                             ////2022-09-24跳过endcell结束单元格所以在的列
@@ -1194,15 +1186,16 @@ namespace MiniExcelLibs.OpenXml
                     {
                         foreach (var alias in pInfo.ExcelColumnAliases)
                         {
-                            if (headersDic.ContainsKey(alias))
+                            if (headersDic.TryGetValue(alias, out var value))
                             {
                                 object newV = null;
-                                object itemValue = item[keys[headersDic[alias]]];
+                                object itemValue = item[keys[value]];
 
                                 if (itemValue == null)
                                     continue;
 
-                                newV = TypeHelper.TypeMapping(v, pInfo, newV, itemValue, rowIndex, startCell, configuration);
+                                newV = TypeHelper.TypeMapping(v, pInfo, newV, itemValue, rowIndex, startCell,
+                                    configuration);
                             }
                         }
                     }
@@ -1213,8 +1206,8 @@ namespace MiniExcelLibs.OpenXml
                         object itemValue = null;
                         if (pInfo.ExcelIndexName != null && keys.Contains(pInfo.ExcelIndexName))
                             itemValue = item[pInfo.ExcelIndexName];
-                        else if (headersDic.ContainsKey(pInfo.ExcelColumnName))
-                            itemValue = item[keys[headersDic[pInfo.ExcelColumnName]]];
+                        else if (headersDic.TryGetValue(pInfo.ExcelColumnName, out var value))
+                            itemValue = item[keys[value]];
 
                         if (itemValue == null)
                             continue;

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -818,7 +818,7 @@ namespace MiniExcelLibs.OpenXml
             // if sheets count > 1 need to read xl/_rels/workbook.xml.rels
             var sheets = _archive.entries.Where(w => w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
                 || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-            );
+            ).ToList();
             ZipArchiveEntry sheetEntry = null;
             if (sheetName != null)
             {
@@ -828,7 +828,7 @@ namespace MiniExcelLibs.OpenXml
                     throw new InvalidOperationException("Please check sheetName/Index is correct");
                 sheetEntry = sheets.Single(w => w.FullName == $"xl/{s.Path}" || w.FullName == $"/xl/{s.Path}" || w.FullName == s.Path || s.Path == $"/{w.FullName}");
             }
-            else if (sheets.Count() > 1)
+            else if (sheets.Count > 1)
             {
                 SetWorkbookRels(_archive.entries);
                 var s = _sheetRecords[0];

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -136,21 +136,19 @@
             if (props.Count == 0)
                 throw new InvalidOperationException($"{type.Name} un-ignore properties count can't be 0");
 
+            var withCustomIndexProps = props.Where(w => w.ExcelColumnIndex != null && w.ExcelColumnIndex > -1);
+            if (withCustomIndexProps.GroupBy(g => g.ExcelColumnIndex).Any(_ => _.Count() > 1))
+                throw new InvalidOperationException("Duplicate column name");
+            var maxkey = keys.Last();
+            var maxIndex = ColumnHelper.GetColumnIndex(maxkey);
+            foreach (var p in props)
             {
-                var withCustomIndexProps = props.Where(w => w.ExcelColumnIndex != null && w.ExcelColumnIndex > -1);
-                if (withCustomIndexProps.GroupBy(g => g.ExcelColumnIndex).Any(_ => _.Count() > 1))
-                    throw new InvalidOperationException($"Duplicate column name");
-                var maxkey = keys.Last();
-                var maxIndex = ColumnHelper.GetColumnIndex(maxkey);
-                foreach (var p in props)
+                if (p.ExcelColumnIndex != null)
                 {
-                    if (p.ExcelColumnIndex != null)
-                    {
-                        if (p.ExcelColumnIndex > maxIndex)
-                            throw new ArgumentException($"ExcelColumnIndex {p.ExcelColumnIndex} over haeder max index {maxkey}");
-                        if (p.ExcelColumnName == null)
-                            throw new InvalidOperationException($"{p.Property.Info.DeclaringType.Name} {p.Property.Name}'s ExcelColumnIndex {p.ExcelColumnIndex} can't find excel column name");
-                    }
+                    if (p.ExcelColumnIndex > maxIndex)
+                        throw new ArgumentException($"ExcelColumnIndex {p.ExcelColumnIndex} over haeder max index {maxkey}");
+                    if (p.ExcelColumnName == null)
+                        throw new InvalidOperationException($"{p.Property.Info.DeclaringType.Name} {p.Property.Name}'s ExcelColumnIndex {p.ExcelColumnIndex} can't find excel column name");
                 }
             }
 

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -88,12 +88,12 @@
             // https://github.com/shps951023/MiniExcel/issues/142
             //TODO: need optimize performance
 
-            var withCustomIndexProps = props.Where(w => w.ExcelColumnIndex != null && w.ExcelColumnIndex > -1);
+            var withCustomIndexProps = props.Where(w => w.ExcelColumnIndex != null && w.ExcelColumnIndex > -1).ToList();
             if (withCustomIndexProps.GroupBy(g => g.ExcelColumnIndex).Any(_ => _.Count() > 1))
-                throw new InvalidOperationException($"Duplicate column name");
+                throw new InvalidOperationException("Duplicate column name");
 
             var maxColumnIndex = props.Count - 1;
-            if (withCustomIndexProps.Any())
+            if (withCustomIndexProps.Count != 0)
                 maxColumnIndex = Math.Max((int)withCustomIndexProps.Max(w => w.ExcelColumnIndex), maxColumnIndex);
 
             var withoutCustomIndexProps = props.Where(w => w.ExcelColumnIndex == null || w.ExcelColumnIndex == -1).ToList();

--- a/src/MiniExcel/Utils/ListHelper.cs
+++ b/src/MiniExcel/Utils/ListHelper.cs
@@ -8,14 +8,15 @@
     {
         public static bool StartsWith<T>(this IList<T> span, IList<T> value) where T : IEquatable<T>
         {
-            if (value.Count() == 0)
+            if (value.Count == 0)
                 return true;
 
-            var b = span.Take(value.Count());
-            if (b.Count() != value.Count())
+            var b = span.Take(value.Count);
+            var bCount = b.Count();
+            if (bCount != value.Count)
                 return false;
 
-            for (int i = 0; i < b.Count(); i++)
+            for (int i = 0; i < bCount; i++)
                 if (!span[i].Equals(value[i]))
                     return false;
 


### PR DESCRIPTION
Hello, I was going through the repository and noticed some potential improvements so I made the following edits:

- Switched most `ContainsKey` calls to `TryGetValue` to avoid going through a dictionary's hashmap twice
- Materialized some `Enumerables` to make sure not to evaluate them multiple times in a row
- Changed `IEnumerable`'s `Count()` method to `ICollection`'s `Count` property to avoid unnecessary enumeration of the collection
- Added safe cast of `IDisposable` to `IEnumerator` to prevent possible memory leak scenarios of implementations not getting garbage collected correctly

I hope it doesn't look presumptuous of me to propose these many modifications at once but I figured at least some of them could be useful. I ran all the tests multiple times and everything seems to be in order. What do you think?