### PR TITLE
Fixed issue #735

### DIFF
--- a/src/MiniExcel/MiniExcel.cs
+++ b/src/MiniExcel/MiniExcel.cs
@@ -31,7 +31,7 @@
 
             if (!File.Exists(path))
             {
-                SaveAs(path, value, printHeader, sheetName, excelType);
+                SaveAs(path, value, printHeader, sheetName, excelType, configuration);
             }
             else
             {
@@ -56,7 +56,7 @@
             {
                 object v = null;
                 {
-                    if (!(value is IEnumerable) && !(value is IDataReader) && !(value is IDictionary<string, object>) && !(value is IDictionary))
+                    if (!(value is IEnumerable) && !(value is IDataReader))
                         v = Enumerable.Range(0, 1).Select(s => value);
                     else
                         v = value;


### PR DESCRIPTION
Added missing `configuration` parameter in a call to `MiniExcel.SaveAs` in method `MiniExcel.Insert`, which caused the configuration not to be used when creating a new file and inserting rows from an IDataReader.

Also simplified the check 
`if (!(value is IEnumerable) && !(value is IDataReader) && !(value is IDictionary<string, object>) && !(value is IDictionary))`
 to
`if (!(value is IEnumerable) && !(value is IDataReader))`
as they're logically equivalent