### PR TITLE
Removing superfluous DateTimeHelper.FromOADate, added IASyncDispoable call to async writer, minor other fixes

### DIFF
--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -13,20 +13,18 @@ namespace MiniExcelLibs.Csv
 {
     internal class CsvWriter : IExcelWriter, IDisposable
     {
-        private readonly Stream _stream;
+        private readonly StreamWriter _writer;
         private readonly CsvConfiguration _configuration;
         private readonly bool _printHeader;
-        private object _value;
-        private readonly StreamWriter _writer;
+        private readonly object _value;
         private bool _disposedValue;
 
         public CsvWriter(Stream stream, object value, IConfiguration configuration, bool printHeader)
         {
-            _stream = stream;
             _configuration = configuration == null ? CsvConfiguration.DefaultConfiguration : (CsvConfiguration)configuration;
             _printHeader = printHeader;
             _value = value;
-            _writer = _configuration.StreamWriterFunc(_stream);
+            _writer = _configuration.StreamWriterFunc(stream);
         }
 
         public int[] SaveAs()

--- a/src/MiniExcel/ExcelFactory.cs
+++ b/src/MiniExcel/ExcelFactory.cs
@@ -17,7 +17,7 @@
                 case ExcelType.XLSX:
                     return new ExcelOpenXmlSheetReader(stream, configuration);
                 default:
-                    throw new NotSupportedException("Please Issue for me");
+                    throw new NotSupportedException("Something went wrong. Please report this issue you are experiencing with MiniExcel.");
             }
         }
     }
@@ -55,7 +55,7 @@
                     var valueExtractor = new InputValueExtractor();
                     return new ExcelOpenXmlTemplate(stream, configuration, valueExtractor);
                 default:
-                    throw new NotSupportedException("Please Issue for me");
+                    throw new NotSupportedException("Something went wrong. Please report this issue you are experiencing with MiniExcel.");
             }
         }
     }

--- a/src/MiniExcel/Utils/CustomPropertyHelper.cs
+++ b/src/MiniExcel/Utils/CustomPropertyHelper.cs
@@ -303,10 +303,8 @@ namespace MiniExcelLibs.Utils
                 return false;
             }
 
-            if (type.IsValueType)
-                throw new NotImplementedException($"MiniExcel does not support only {type.Name} value generic type");
-            if (type == typeof(string) || type == typeof(DateTime) || type == typeof(Guid))
-                throw new NotImplementedException($"MiniExcel does not support only {type.Name} generic type");
+            if (type.IsValueType || type == typeof(string))
+                throw new NotSupportedException($"MiniExcel does not support the use of {type.FullName} as a generic type");
 
             if (ValueIsNeededToDetermineProperties(type))
             {

--- a/src/MiniExcel/Utils/DateTimeHelper.cs
+++ b/src/MiniExcel/Utils/DateTimeHelper.cs
@@ -1,13 +1,6 @@
 ﻿namespace MiniExcelLibs.Utils
 {
-    using System;
-
-#if DEBUG
-    public
-#else
-    internal
-#endif
-    static partial class DateTimeHelper
+    public static class DateTimeHelper
     {
         /// <summary>
         /// NumberFormat from NuGet ExcelNumberFormat MIT@License
@@ -18,103 +11,14 @@
         }
 
         /**Below Code from ExcelDataReader @MIT License**/
-        // All OA dates must be greater than (not >=) OADateMinAsDouble
-        public const double OADateMinAsDouble = -657435.0;
+        // All OA dates must be strictly in between OADateMinAsDouble and OADateMaxAsDouble
+        private const double OADateMinAsDouble = -657435.0;
 
-        // All OA dates must be less than (not <=) OADateMaxAsDouble
-        public const double OADateMaxAsDouble = 2958466.0;
+        private const double OADateMaxAsDouble = 2958466.0;
 
-        // From DateTime class to enable OADate in PCL
-        // Number of 100ns ticks per time unit
-        private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
-        private const long TicksPerMinute = TicksPerSecond * 60;
-        private const long TicksPerHour = TicksPerMinute * 60;
-        private const long TicksPerDay = TicksPerHour * 24;
-
-        // Number of milliseconds per time unit
-        private const int MillisPerSecond = 1000;
-        private const int MillisPerMinute = MillisPerSecond * 60;
-        private const int MillisPerHour = MillisPerMinute * 60;
-        private const int MillisPerDay = MillisPerHour * 24;
-
-        // Number of days in a non-leap year
-        private const int DaysPerYear = 365;
-
-        // Number of days in 4 years
-        private const int DaysPer4Years = DaysPerYear * 4 + 1;
-
-        // Number of days in 100 years
-        private const int DaysPer100Years = DaysPer4Years * 25 - 1;
-
-        // Number of days in 400 years
-        private const int DaysPer400Years = DaysPer100Years * 4 + 1;
-
-        // Number of days from 1/1/0001 to 12/30/1899
-        private const int DaysTo1899 = DaysPer400Years * 4 + DaysPer100Years * 3 - 367;
-
-        // Number of days from 1/1/0001 to 12/31/9999
-        private const int DaysTo10000 = DaysPer400Years * 25 - 366;
-
-        private const long MaxMillis = (long)DaysTo10000 * MillisPerDay;
-
-        private const long DoubleDateOffset = DaysTo1899 * TicksPerDay;
-
-        public static DateTime FromOADate(double d)
+        internal static bool IsValidOADateTime(double value)
         {
-            return new DateTime(DoubleDateToTicks(d), DateTimeKind.Unspecified);
-        }
-
-        // duplicated from DateTime
-        internal static long DoubleDateToTicks(double value)
-        {
-            if (value >= OADateMaxAsDouble || value <= OADateMinAsDouble)
-                throw new ArgumentException("Invalid OA Date");
-            long millis = (long)(value * MillisPerDay + (value >= 0 ? 0.5 : -0.5));
-
-            // The interesting thing here is when you have a value like 12.5 it all positive 12 days and 12 hours from 01/01/1899
-            // However if you a value of -12.25 it is minus 12 days but still positive 6 hours, almost as though you meant -11.75 all negative
-            // This line below fixes up the millis in the negative case
-            if (millis < 0)
-            {
-                millis -= millis % MillisPerDay * 2;
-            }
-
-            millis += DoubleDateOffset / TicksPerMillisecond;
-
-            if (millis < 0 || millis >= MaxMillis)
-                throw new ArgumentException("OA Date out of range");
-            return millis * TicksPerMillisecond;
-        }
-
-        public static double AdjustOADateTime(double value, bool date1904)
-        {
-            if (!date1904)
-            {
-                // Workaround for 1900 leap year bug in Excel
-                if (value >= 0.0 && value < 60.0)
-                    return value + 1;
-            }
-            else
-            {
-                return value + 1462.0;
-            }
-
-            return value;
-        }
-
-        public static bool IsValidOADateTime(double value)
-        {
-            return value > DateTimeHelper.OADateMinAsDouble && value < DateTimeHelper.OADateMaxAsDouble;
-        }
-
-        public static object ConvertFromOATime(double value, bool date1904)
-        {
-            var dateValue = AdjustOADateTime(value, date1904);
-            if (IsValidOADateTime(dateValue))
-                return DateTimeHelper.FromOADate(dateValue);
-            return value;
+            return value > OADateMinAsDouble && value < OADateMaxAsDouble;
         }
     }
-
 }

--- a/src/MiniExcel/Utils/TypeHelper.cs
+++ b/src/MiniExcel/Utils/TypeHelper.cs
@@ -1,15 +1,15 @@
-﻿namespace MiniExcelLibs.Utils
-{
-    using MiniExcelLibs.Exceptions;
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Data;
-    using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
+﻿using MiniExcelLibs.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
 
-    internal static partial class TypeHelper
+namespace MiniExcelLibs.Utils
+{
+    internal static class TypeHelper
     {
         public static IEnumerable<IDictionary<string, object>> ConvertToEnumerableDictionary(IDataReader reader)
         {
@@ -19,7 +19,6 @@
                     .ToDictionary(reader.GetName, reader.GetValue);
             }
         }
-
 
         /// <summary>
         /// From : https://stackoverflow.com/questions/906499/getting-type-t-from-ienumerablet
@@ -125,7 +124,7 @@
                 else if (DateTime.TryParseExact(vs, "dd/MM/yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _v2))
                     newValue = _v2;
                 else if (double.TryParse(vs, NumberStyles.None, CultureInfo.InvariantCulture, out var _d))
-                    newValue = DateTimeHelper.FromOADate(_d);
+                    newValue = DateTime.FromOADate(_d);
                 else
                     throw new InvalidCastException($"{vs} cannot be cast to DateTime");
             }

--- a/tests/MiniExcelTests/MiniExcelCsvAsycTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvAsycTests.cs
@@ -77,7 +77,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
                 var table = new Dictionary<string, object>(); //TODO
-                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
+                Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, table));
                 File.Delete(path);
             }
 

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -114,7 +114,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.csv");
                 var table = new Dictionary<string, object>(); //TODO
-                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, table));
+                Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, table));
                 File.Delete(path);
             }
 

--- a/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
@@ -1462,15 +1462,15 @@ namespace MiniExcelLibs.Tests
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid().ToString()}.xlsx");
             //MiniExcel.SaveAs(path, new[] { "1", "2" });
-            await Assert.ThrowsAnyAsync<NotImplementedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { 1, 2 }));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { 1, 2 }));
             File.Delete(path);
-            await Assert.ThrowsAnyAsync<NotImplementedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { "1", "2" }));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { "1", "2" }));
             File.Delete(path);
-            await Assert.ThrowsAnyAsync<NotImplementedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { '1', '2' }));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { '1', '2' }));
             File.Delete(path);
-            await Assert.ThrowsAnyAsync<NotImplementedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { DateTime.Now }));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { DateTime.Now }));
             File.Delete(path);
-            await Assert.ThrowsAnyAsync<NotImplementedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { Guid.NewGuid() }));
+            await Assert.ThrowsAnyAsync<NotSupportedException>(async () => await MiniExcel.SaveAsAsync(path, new[] { Guid.NewGuid() }));
             File.Delete(path);
         }
 

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -3177,15 +3177,15 @@ Leave";
         {
             var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
             //MiniExcel.SaveAs(path, new[] { "1", "2" });
-            Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, new[] { 1, 2 }));
+            Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, new[] { 1, 2 }));
             File.Delete(path);
-            Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, new[] { "1", "2" }));
+            Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, new[] { "1", "2" }));
             File.Delete(path);
-            Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, new[] { '1', '2' }));
+            Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, new[] { '1', '2' }));
             File.Delete(path);
-            Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, new[] { DateTime.Now }));
+            Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, new[] { DateTime.Now }));
             File.Delete(path);
-            Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, new[] { Guid.NewGuid() }));
+            Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, new[] { Guid.NewGuid() }));
             File.Delete(path);
         }
 

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using MiniExcelLibs.Utils;
 using Xunit;
 using Xunit.Abstractions;
 using static MiniExcelLibs.Tests.MiniExcelOpenXmlTests;
@@ -1749,7 +1750,7 @@ namespace MiniExcelLibs.Tests
 
         private static bool IsDateFormatString(string formatCode)
         {
-            return MiniExcelLibs.Utils.DateTimeHelper.IsDateTimeFormat(formatCode);
+            return DateTimeHelper.IsDateTimeFormat(formatCode);
         }
 
         [Fact]

--- a/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlAsyncTests.cs
@@ -613,7 +613,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
                 var values = new List<int>();
-                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAsAsync(path, values).GetAwaiter().GetResult());
+                Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAsAsync(path, values).GetAwaiter().GetResult());
                 File.Delete(path);
             }
         }

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -648,7 +648,7 @@ namespace MiniExcelLibs.Tests
             {
                 var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.xlsx");
                 var values = new List<int>();
-                Assert.Throws<NotImplementedException>(() => MiniExcel.SaveAs(path, values));
+                Assert.Throws<NotSupportedException>(() => MiniExcel.SaveAs(path, values));
             }
         }
 


### PR DESCRIPTION
- Resolves #592: The implementation of `DateTimeHelper.FromOADate` was equivalent to the standard `DateTime.FromOADate` already present in the framework. Although not being identical due to the latter using magic numbers instead of calculating some of the quantities, unwrapping those calculations showed a 1-1 match.
- Resolves #605: Changed `using` statements to `await using` when compiling for .NET5+ so that `DisposeAsync` is called instead of `Dispose`
-  Closes #503 by clearing up the exception message

**Edit**: Changed `NotImplementedException` assertions in some tests to `NotSupportedException` after the modification in the previous commit that also exchanged the two exception types