### PR TITLE
Optimization of SaveAsTemplate method

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlUtils.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlUtils.cs
@@ -14,15 +14,15 @@
         /// <summary>
         /// Encode to XML (special characteres: &apos; &quot; &gt; &lt; &amp;)
         /// </summary>
-        public static string EncodeXML(string value) => value == null
-                  ? string.Empty
-                  : XmlEncoder.EncodeString(value)
-                              .Replace("&", "&amp;")
-                              .Replace("<", "&lt;")
-                              .Replace(">", "&gt;")
-                              .Replace("\"", "&quot;")
-                              .Replace("'", "&apos;")
-                              .ToString();
+        public static string EncodeXML(string value) 
+            => value == null ? string.Empty 
+            : XmlEncoder.EncodeString(value)
+                      .Replace("&", "&amp;")
+                      .Replace("<", "&lt;")
+                      .Replace(">", "&gt;")
+                      .Replace("\"", "&quot;")
+                      .Replace("'", "&apos;")
+                      .ToString();
 
         /// <summary>X=CellLetter,Y=CellNumber,ex:A1=(1,1),B2=(2,2)</summary>
         public static string ConvertXyToCell(Tuple<int, int> xy)
@@ -34,14 +34,14 @@
         public static string ConvertXyToCell(int x, int y)
         {
             int dividend = x;
-            string columnName = String.Empty;
+            string columnName = string.Empty;
             int modulo;
 
             while (dividend > 0)
             {
                 modulo = (dividend - 1) % 26;
-                columnName = Convert.ToChar(65 + modulo).ToString() + columnName;
-                dividend = (int)((dividend - modulo) / 26);
+                columnName = Convert.ToChar(65 + modulo) + columnName;
+                dividend = (dividend - modulo) / 26;
             }
             return $"{columnName}{y}";
         }

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.MergeCells.cs
@@ -30,38 +30,35 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
             stream.CopyTo(_stream);
 
             var reader = new ExcelOpenXmlSheetReader(_stream, null);
-            var _archive = new ExcelOpenXmlZip(_stream, mode: ZipArchiveMode.Update, true, Encoding.UTF8);
+            var archive = new ExcelOpenXmlZip(_stream, mode: ZipArchiveMode.Update, true, Encoding.UTF8);
+            
+            //read sharedString
+            var sharedStrings = reader._sharedStrings;
+
+            //read all xlsx sheets
+            var sheets = archive.zipFile.Entries.Where(w =>
+                w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
+                w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
+            ).ToList();
+
+            foreach (var sheet in sheets)
             {
-                //read sharedString
-                var sharedStrings = reader._sharedStrings;
+                _xRowInfos = new List<XRowInfo>(); //every time need to use new XRowInfos or it'll cause duplicate problem: https://user-images.githubusercontent.com/12729184/115003101-0fcab700-9ed8-11eb-9151-ca4d7b86d59e.png
+                _xMergeCellInfos = new Dictionary<string, XMergeCell>();
+                _newXMergeCellInfos = new List<XMergeCell>();
 
-                //read all xlsx sheets
-                var sheets = _archive.zipFile.Entries.Where(w =>
-                    w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-                    || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-                ).ToList();
+                var sheetStream = sheet.Open();
+                var fullName = sheet.FullName;
 
-                foreach (var sheet in sheets)
+                var entry = archive.zipFile.CreateEntry(fullName);
+                using (var zipStream = entry.Open())
                 {
-                    this.XRowInfos =
-                        new List<XRowInfo>(); //every time need to use new XRowInfos or it'll cause duplicate problem: https://user-images.githubusercontent.com/12729184/115003101-0fcab700-9ed8-11eb-9151-ca4d7b86d59e.png
-                    this.XMergeCellInfos = new Dictionary<string, XMergeCell>();
-                    this.NewXMergeCellInfos = new List<XMergeCell>();
-
-                    var sheetStream = sheet.Open();
-                    var fullName = sheet.FullName;
-
-                    ZipArchiveEntry entry = _archive.zipFile.CreateEntry(fullName);
-                    using (var zipStream = entry.Open())
-                    {
-                        GenerateSheetXmlImpl(sheet, zipStream, sheetStream, new Dictionary<string, object>(),
-                            sharedStrings, mergeCells: true);
-                        //doc.Save(zipStream); //don't do it beacause : ![image](https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png)
-                    }
+                    GenerateSheetXmlImpl(sheet, zipStream, sheetStream, new Dictionary<string, object>(), sharedStrings, mergeCells: true);
+                    //doc.Save(zipStream); //don't do it beacause: https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png
                 }
             }
 
-            _archive.zipFile.Dispose();
+            archive.zipFile.Dispose();
         }
 
         public Task MergeSameCellsAsync(string path, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
@@ -1,35 +1,39 @@
-﻿namespace MiniExcelLibs.OpenXml.SaveByTemplate
-{
-    using MiniExcelLibs.Utils;
-    using MiniExcelLibs.Zip;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.IO.Compression;
-    using System.Linq;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Xml;
+﻿using MiniExcelLibs.Utils;
+using MiniExcelLibs.Zip;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
 
+namespace MiniExcelLibs.OpenXml.SaveByTemplate
+{
     internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsync
     {
+#if NET7_0_OR_GREATER
+        [GeneratedRegex("(?<={{).*?(?=}})")] private static partial Regex ExpressionRegex();
+        private static readonly Regex _isExpressionRegex = ExpressionRegex();
+#else
+        private static readonly Regex _isExpressionRegex = new Regex("(?<={{).*?(?=}})");
+#endif 
         private static readonly XmlNamespaceManager _ns;
-        private static readonly Regex _isExpressionRegex;
-
-        static ExcelOpenXmlTemplate()
-        {
-            _isExpressionRegex = new Regex("(?<={{).*?(?=}})");
-            _ns = new XmlNamespaceManager(new NameTable());
-            _ns.AddNamespace("x", Config.SpreadsheetmlXmlns);
-            _ns.AddNamespace("x14ac", Config.SpreadsheetmlXml_x14ac);
-        }
 
         private readonly Stream _stream;
         private readonly OpenXmlConfiguration _configuration;
         private readonly IInputValueExtractor _inputValueExtractor;
         private readonly StringBuilder _calcChainContent = new StringBuilder();
+
+        static ExcelOpenXmlTemplate()
+        {
+            _ns = new XmlNamespaceManager(new NameTable());
+            _ns.AddNamespace("x", Config.SpreadsheetmlXmlns);
+            _ns.AddNamespace("x14ac", Config.SpreadsheetmlXml_x14ac);
+        }
 
         public ExcelOpenXmlTemplate(Stream stream, IConfiguration configuration, InputValueExtractor inputValueExtractor)
         {
@@ -50,75 +54,69 @@
                 SaveAsByTemplateImpl(stream, value);
         }
 
-        public void SaveAsByTemplateImpl(Stream templateStream, object value)
+        internal void SaveAsByTemplateImpl(Stream templateStream, object value)
         {
             //only support xlsx
             templateStream.CopyTo(_stream);
 
             var reader = new ExcelOpenXmlSheetReader(_stream, null);
-            var _archive = new ExcelOpenXmlZip(_stream, mode: ZipArchiveMode.Update, true, Encoding.UTF8);
+            var archive = new ExcelOpenXmlZip(_stream, mode: ZipArchiveMode.Update, true, Encoding.UTF8);
+            
+            //read sharedString
+            var sharedStrings = reader._sharedStrings;
+
+            //read all xlsx sheets
+            var sheets = archive.zipFile.Entries
+                .Where(w =>
+                    w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
+                    w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            int sheetIdx = 0;
+            foreach (var sheet in sheets)
             {
-                //read sharedString
-                var sharedStrings = reader._sharedStrings;
-                StringBuilder calcSheetContent = new StringBuilder();
+                //every time need to use new XRowInfos or it'll cause duplicate problem: https://user-images.githubusercontent.com/12729184/115003101-0fcab700-9ed8-11eb-9151-ca4d7b86d59e.png
+                _xRowInfos = new List<XRowInfo>();
+                _xMergeCellInfos = new Dictionary<string, XMergeCell>();
+                _newXMergeCellInfos = new List<XMergeCell>();
 
-                //read all xlsx sheets
-                var sheets = _archive.zipFile.Entries.Where(w =>
-                    w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-                    || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-                ).ToList();
+                var sheetStream = sheet.Open();
+                var fullName = sheet.FullName;
 
-                int sheetIdx = 0;
-                foreach (var sheet in sheets)
+                var inputValues = _inputValueExtractor.ToValueDictionary(value);
+                var entry = archive.zipFile.CreateEntry(fullName);
+                using (var zipStream = entry.Open())
                 {
-                    this.XRowInfos =
-                        new List<XRowInfo>(); //every time need to use new XRowInfos or it'll cause duplicate problem: https://user-images.githubusercontent.com/12729184/115003101-0fcab700-9ed8-11eb-9151-ca4d7b86d59e.png
-                    this.XMergeCellInfos = new Dictionary<string, XMergeCell>();
-                    this.NewXMergeCellInfos = new List<XMergeCell>();
-
-                    var sheetStream = sheet.Open();
-                    var fullName = sheet.FullName;
-
-                    var inputValues = _inputValueExtractor.ToValueDictionary(value);
-                    ZipArchiveEntry entry = _archive.zipFile.CreateEntry(fullName);
-                    using (var zipStream = entry.Open())
-                    {
-                        GenerateSheetXmlImpl(sheet, zipStream, sheetStream, inputValues, sharedStrings, false);
-                        //doc.Save(zipStream); //don't do it because : ![image](https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png)
-                    }
-
-                    // disposing writer disposes streams as well. reopen the entry to read and parse calc functions
-                    using (var filledStream = entry.Open())
-                    {
-                        sheetIdx++;
-                        _calcChainContent.Append(CalcChainHelper.GetCalcChainContent(CalcChainCellRefs, sheetIdx));
-                    }
-                }
-
-                var calcChain = _archive.zipFile.Entries.FirstOrDefault(e => e.FullName.Contains("xl/calcChain.xml"));
-                if (calcChain != null)
-                {
-                    string calcChainPathname = calcChain.FullName;
-                    calcChain.Delete();
-                    var calcChainEntry = _archive.zipFile.CreateEntry(calcChainPathname);
-                    using (var calcChainStream = calcChainEntry.Open())
-                    {
-                        CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());
-                    }
+                    GenerateSheetXmlImpl(sheet, zipStream, sheetStream, inputValues, sharedStrings, false);
+                    //doc.Save(zipStream); //don't do it because: https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png
+                    // disposing writer disposes streams as well. read and parse calc functions before that
+                    sheetIdx++;
+                    _calcChainContent.Append(CalcChainHelper.GetCalcChainContent(_calcChainCellRefs, sheetIdx));
                 }
             }
 
-            _archive.zipFile.Dispose();
+            var calcChain = archive.zipFile.Entries.FirstOrDefault(e => e.FullName.Contains("xl/calcChain.xml"));
+            if (calcChain != null)
+            {
+                var calcChainPathName = calcChain.FullName;
+                calcChain.Delete();
+                
+                var calcChainEntry = archive.zipFile.CreateEntry(calcChainPathName);
+                using (var calcChainStream = calcChainEntry.Open())
+                {
+                    CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());
+                }
+            }
+
+            archive.zipFile.Dispose();
         }
 
-        public Task SaveAsByTemplateAsync(string templatePath, object value,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public Task SaveAsByTemplateAsync(string templatePath, object value, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => SaveAsByTemplate(templatePath, value), cancellationToken);
         }
 
-        public Task SaveAsByTemplateAsync(byte[] templateBtyes, object value,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public Task SaveAsByTemplateAsync(byte[] templateBtyes, object value, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => SaveAsByTemplate(templateBtyes, value), cancellationToken);
         }

--- a/src/MiniExcel/SaveByTemplate/InputValueExtractor.cs
+++ b/src/MiniExcel/SaveByTemplate/InputValueExtractor.cs
@@ -15,12 +15,11 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
 
         private static IDictionary<string, object> GetValuesFromDictionary(Dictionary<string, object> valueDictionary)
         {
-            return valueDictionary
-                .ToDictionary(
-                    x => x.Key,
-                    x => x.Value is IDataReader dataReader
-                        ? TypeHelper.ConvertToEnumerableDictionary(dataReader).ToList()
-                        : x.Value);
+            return valueDictionary.ToDictionary(
+                x => x.Key,
+                x => x.Value is IDataReader dataReader
+                    ? TypeHelper.ConvertToEnumerableDictionary(dataReader).ToList()
+                    : x.Value);
         }
 
         private static IDictionary<string, object> GetValuesFromObject(object valueObject)

--- a/src/MiniExcel/Utils/StringHelper.cs
+++ b/src/MiniExcel/Utils/StringHelper.cs
@@ -1,27 +1,19 @@
-﻿namespace MiniExcelLibs.Utils
+﻿using MiniExcelLibs.OpenXml;
+using System.Linq;
+using System.Text;
+using System.Xml;
+    
+namespace MiniExcelLibs.Utils
 {
-    using MiniExcelLibs.OpenXml;
-    using System;
-    using System.Linq;
-    using System.Text;
-    using System.Xml;
-
     internal static class StringHelper
     {
         private static readonly string[] _ns = { Config.SpreadsheetmlXmlns, Config.SpreadsheetmlXmlStrictns };
-        public static string GetLetter(string content)
-        {
-            //TODO:need to chekc
-            return new String(content.Where(Char.IsLetter).ToArray());
-        }
-
-        public static int GetNumber(string content)
-        {
-            return int.Parse(new String(content.Where(Char.IsNumber).ToArray()));
-        }
+        public static string GetLetter(string content) => content.FirstOrDefault(char.IsLetter).ToString();
+        public static int GetDigit(string content) => content.FirstOrDefault(char.IsDigit) - '0';
+        public static int GetNumber(string content) => int.Parse(new string(content.Where(char.IsNumber).ToArray()));
 
         /// <summary>
-        /// Copy&Modify from ExcelDataReader @MIT License
+        /// Copied and modified from ExcelDataReader - @MIT License
         /// </summary>
         public static string ReadStringItem(XmlReader reader)
         {
@@ -50,7 +42,7 @@
         }
 
         /// <summary>
-        /// Copy&Modify from ExcelDataReader @MIT License
+        /// Copied and modified from ExcelDataReader - @MIT License
         /// </summary>
         private static string ReadRichTextRun(XmlReader reader)
         {
@@ -73,5 +65,4 @@
             return result.ToString();
         }
     }
-
 }


### PR DESCRIPTION
- Closes #742 by solving two major bottlenecks in methods `UpdateDimensionAndGetRowsInfo` and `WriteSheetXml`, making the process of saving by template about 30 times faster and 10% less resource intensive on very large templates.
- Moved the process of merging cells outside of the `WriteSheetXml` method
- Some other minor refactoring and code cleanup