### PR TITLE
Added option to quote csv values containing whitespaces, fixed benchmark workflow file, other minor changes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,7 @@
 name: MiniExcel Benchmarks
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -29,19 +30,14 @@ jobs:
         env:
           BenchmarkMode: Automatic
           BenchmarkSection: query
-      - name: Commit report
-        working-directory: ./benchmarks
-        run: |
-          cp -r ./MiniExcel.Benchmarks/BenchmarkDotNet.Artifacts/results ./
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git pull
-          cd ./results
-          git add '*.md'
-          git commit -am "Automated benchmark report - query section"
-          git push --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Renaming result file
+        run: mv MiniExcelLibs.Benchmarks.XlsxBenchmark-report-github.md query-benchmark.md
+        working-directory: ./benchmarks/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results
+      - name: Save benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: query-benchmark-result
+          path: ./benchmark/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results/*.md
           
   CreateBenchmark:
     runs-on: ubuntu-latest
@@ -64,20 +60,15 @@ jobs:
         env:
           BenchmarkMode: Automatic
           BenchmarkSection: create
-      - name: Commit report
-        working-directory: ./benchmarks
-        run: |
-          cp -r ./MiniExcel.Benchmarks/BenchmarkDotNet.Artifacts/results ./
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git pull
-          cd ./results
-          git add '*.md'
-          git commit -am "Automated benchmark report - create section"
-          git push --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
-  
+      - name: Renaming result file
+        run: mv MiniExcelLibs.Benchmarks.XlsxBenchmark-report-github.md create-benchmark.md
+        working-directory: ./benchmarks/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results
+      - name: Save benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: create-benchmark-result
+          path: ./benchmark/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results/*.md
+          
   TemplateBenchmark:
     runs-on: ubuntu-latest
   
@@ -99,16 +90,33 @@ jobs:
         env:
           BenchmarkMode: Automatic
           BenchmarkSection: template
-      - name: Commit report
-        working-directory: ./benchmarks
+      - name: Renaming result file
+        run: mv MiniExcelLibs.Benchmarks.XlsxBenchmark-report-github.md template-benchmark.md
+        working-directory: ./benchmarks/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results        
+      - name: Save benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: template-benchmark-result
+          path: ./benchmark/MiniExcel.Benchmarks/BenchMarkDotNet.Artifacts/results/*.md
+
+  PushBenchmarksResults:
+    runs-on: ubuntu-latest
+    needs: [ QueryBenchmark, CreateBenchmark, TemplateBenchmark ]
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch benchmark results
+        uses: actions/download-artifact@v4
+        with:
+            path: ./benchmarks/results
+            merge-multiple: true
+      - name: Commit reports
+        working-directory: ./benchmarks/results
         run: |
-          cp -r ./MiniExcel.Benchmarks/BenchmarkDotNet.Artifacts/results ./
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git pull
-          cd ./results
-          git add '*.md'
-          git commit -am "Automated benchmark report - template section"
-          git push --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git add ./*.md
+          git commit -am "Automated benchmark report - ${{ github.ref_name }}"
+          git push origin master --force-with-lease

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET 8
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Setup .NET 9
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies

--- a/MiniExcel.sln
+++ b/MiniExcel.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs and setting", "Docs an
 		README.md = README.md
 		README.zh-CN.md = README.zh-CN.md
 		README.zh-Hant.md = README.zh-Hant.md
+		.github\workflows\benchmark.yml = .github\workflows\benchmark.yml
+		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CC1E0601-AEC9-42D7-8F6A-3FB3939EED16}"

--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ MiniExcel.AddPicture(path, images);
 #### 7. Get Sheets Dimension
 
 ```csharp
-var dim = MiniExcel.GetSheetsDimensions(path);
+var dim = MiniExcel.GetSheetDimensions(path);
 ```
 
 ### Examples:

--- a/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
+++ b/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
@@ -10,13 +10,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-		<PackageReference Include="ClosedXML" Version="0.102.3" />
-		<PackageReference Include="ClosedXML.Report" Version="0.2.11" />
-		<PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
-		<PackageReference Include="EPPlus" Version="7.7.0" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+		<PackageReference Include="ClosedXML" Version="0.105.0" />
+		<PackageReference Include="ClosedXML.Report" Version="0.2.12" />
+		<PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+		<PackageReference Include="EPPlus" Version="7.7.2" />
 		<PackageReference Include="ExcelDataReader" Version="3.7.0" />
-		<PackageReference Include="System.IO.Packaging" Version="9.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/benchmarks/MiniExcel.Benchmarks/Program.cs
+++ b/benchmarks/MiniExcel.Benchmarks/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using MiniExcelLibs.Benchmarks;
 using MiniExcelLibs.Benchmarks.BenchmarkSections;
 
@@ -11,12 +10,19 @@ if (Environment.GetEnvironmentVariable("BenchmarkMode") == "Automatic")
         "query" => typeof(QueryXlsxBenchmark),
         "create" => typeof(CreateXlsxBenchmark),
         "template" => typeof(TemplateXlsxBenchmark),
-        _ => throw new InvalidEnumArgumentException($"Benchmark section {section} does not exist")
+        _ => throw new ArgumentException($"Benchmark section {section} does not exist")
     };
     
     BenchmarkRunner.Run(benchmark, new Config(), args);
 }
 else
+{
     BenchmarkSwitcher
-        .FromTypes([typeof(CreateXlsxBenchmark)])
+        .FromTypes(
+        [
+            typeof(QueryXlsxBenchmark),
+            typeof(CreateXlsxBenchmark),
+            typeof(TemplateXlsxBenchmark)
+        ])
         .Run(args, new Config());
+}

--- a/src/MiniExcel/Csv/CsvConfiguration.cs
+++ b/src/MiniExcel/Csv/CsvConfiguration.cs
@@ -6,18 +6,19 @@ namespace MiniExcelLibs.Csv
 {
     public class CsvConfiguration : Configuration
     {
-        private static Encoding _defaultEncoding = new UTF8Encoding(true);
+        private static readonly Encoding DefaultEncoding = new UTF8Encoding(true);
 
         public char Seperator { get; set; } = ',';
         public string NewLine { get; set; } = "\r\n";
         public bool ReadLineBreaksWithinQuotes { get; set; } = true;
         public bool ReadEmptyStringAsNull { get; set; } = false;
         public bool AlwaysQuote { get; set; } = false;
+        public bool QuoteWhitespaces { get; set; } = true;
         public Func<string, string[]> SplitFn { get; set; }
-        public Func<Stream, StreamReader> StreamReaderFunc { get; set; } = (stream) => new StreamReader(stream, _defaultEncoding);
-        public Func<Stream, StreamWriter> StreamWriterFunc { get; set; } = (stream) => new StreamWriter(stream, _defaultEncoding);
+        public Func<Stream, StreamReader> StreamReaderFunc { get; set; } = (stream) => new StreamReader(stream, DefaultEncoding);
+        public Func<Stream, StreamWriter> StreamWriterFunc { get; set; } = (stream) => new StreamWriter(stream, DefaultEncoding);
 
-        internal readonly static CsvConfiguration DefaultConfiguration = new CsvConfiguration();
+        internal static readonly CsvConfiguration DefaultConfiguration = new CsvConfiguration();
     }
 }
 

--- a/src/MiniExcel/Csv/CsvHelpers.cs
+++ b/src/MiniExcel/Csv/CsvHelpers.cs
@@ -3,7 +3,7 @@
     internal static class CsvHelpers
     {
         /// <summary>If content contains special characters then use "{value}" format</summary>
-        public static string ConvertToCsvValue(string value, bool alwaysQuote, char separator)
+        public static string ConvertToCsvValue(string value, CsvConfiguration configuration)
         {
             if (value == null)
                 return string.Empty;
@@ -13,16 +13,14 @@
                 value = value.Replace("\"", "\"\"");
                 return $"\"{value}\"";
             }
-
-            if (value.Contains(separator.ToString()) || value.Contains(" ") || value.Contains("\n") || value.Contains("\r"))
-            {
-                return $"\"{value}\"";
-            }
-
-            if (alwaysQuote)
-                return $"\"{value}\"";
-
-            return value;
+            
+            var shouldQuote = configuration.AlwaysQuote ||
+                              (configuration.QuoteWhitespaces && value.Contains(" ")) ||
+                              value.Contains(configuration.Seperator.ToString()) ||
+                              value.Contains("\r") ||
+                              value.Contains("\n");
+            
+            return shouldQuote ? $"\"{value}\"" : value;
         }
     }
 }

--- a/src/MiniExcel/Csv/CsvWriter.cs
+++ b/src/MiniExcel/Csv/CsvWriter.cs
@@ -49,7 +49,7 @@ namespace MiniExcelLibs.Csv
 
         private void AppendColumn(StringBuilder rowBuilder, CellWriteInfo column)
         {
-            rowBuilder.Append(CsvHelpers.ConvertToCsvValue(ToCsvString(column.Value, column.Prop), _configuration.AlwaysQuote, _configuration.Seperator));
+            rowBuilder.Append(CsvHelpers.ConvertToCsvValue(ToCsvString(column.Value, column.Prop), _configuration));
             rowBuilder.Append(_configuration.Seperator);
         }
 
@@ -63,7 +63,7 @@ namespace MiniExcelLibs.Csv
 
         private string GetHeader(List<ExcelColumnInfo> props) => string.Join(
             _configuration.Seperator.ToString(),
-            props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName, _configuration.AlwaysQuote, _configuration.Seperator)));
+            props.Select(s => CsvHelpers.ConvertToCsvValue(s?.ExcelColumnName, _configuration)));
 
         private int WriteValues(object values)
         {

--- a/src/MiniExcel/OpenXml/SharedStringsDiskCache.cs
+++ b/src/MiniExcel/OpenXml/SharedStringsDiskCache.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace MiniExcelLibs.OpenXml
@@ -37,9 +36,11 @@ namespace MiniExcelLibs.OpenXml
         {
             if (index > _maxIndx)
                 _maxIndx = index;
-            byte[] valueBs = _encoding.GetBytes(value);
+            
+            var valueBs = _encoding.GetBytes(value);
             if (value.Length > 32767) //check info length, becasue cell string max length is 47483647
-                throw new ArgumentOutOfRangeException("Excel one cell max length is 32,767 characters");
+                throw new ArgumentOutOfRangeException("", "Excel one cell max length is 32,767 characters");
+            
             _positionFs.Write(BitConverter.GetBytes(_valueFs.Position), 0, 4);
             _lengthFs.Write(BitConverter.GetBytes(valueBs.Length), 0, 4);
             _valueFs.Write(valueBs, 0, valueBs.Length);
@@ -49,16 +50,19 @@ namespace MiniExcelLibs.OpenXml
         {
             _positionFs.Position = index * 4;
             var bytes = new byte[4];
-            _positionFs.Read(bytes, 0, 4);
+            _ = _positionFs.Read(bytes, 0, 4);
             var position = BitConverter.ToInt32(bytes, 0);
+            
+            bytes = new byte[4];
             _lengthFs.Position = index * 4;
-            _lengthFs.Read(bytes, 0, 4);
+            _ = _lengthFs.Read(bytes, 0, 4);
             var length = BitConverter.ToInt32(bytes, 0);
-            _valueFs.Position = position;
+            
             bytes = new byte[length];
-            _valueFs.Read(bytes, 0, length);
-            var v = _encoding.GetString(bytes);
-            return v;
+            _valueFs.Position = position;
+            _ = _valueFs.Read(bytes, 0, length);
+
+            return _encoding.GetString(bytes);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -69,15 +73,19 @@ namespace MiniExcelLibs.OpenXml
                 {
                     // TODO: dispose managed state (managed objects)
                 }
+                
                 _positionFs.Dispose();
                 if (File.Exists(_positionFs.Name))
                     File.Delete(_positionFs.Name);
+                
                 _lengthFs.Dispose();
                 if (File.Exists(_lengthFs.Name))
                     File.Delete(_lengthFs.Name);
+                
                 _valueFs.Dispose();
                 if (File.Exists(_valueFs.Name))
                     File.Delete(_valueFs.Name);
+                
                 _disposedValue = true;
             }
         }

--- a/src/MiniExcel/Utils/ExcelTypeHelper.cs
+++ b/src/MiniExcel/Utils/ExcelTypeHelper.cs
@@ -32,7 +32,10 @@ namespace MiniExcelLibs.Utils
 
             var probe = new byte[8];
             stream.Seek(0, SeekOrigin.Begin);
-            stream.Read(probe, 0, probe.Length);
+            var read = stream.Read(probe, 0, probe.Length);
+            if (read != probe.Length)
+                throw new InvalidDataException("The file/stream does not contain enough data to process");
+            
             stream.Seek(0, SeekOrigin.Begin);
 
             // New office format (can be any ZIP archive)
@@ -41,7 +44,7 @@ namespace MiniExcelLibs.Utils
                 return ExcelType.XLSX;
             }
 
-            throw new NotSupportedException("Stream cannot know the file type, please specify ExcelType manually");
+            throw new InvalidDataException("The file type could not be inferred automatically, please specify ExcelType manually");
         }
     }
 }

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -203,14 +203,14 @@ public class MiniExcelCsvTests
                 var records = csv.GetRecords<dynamic>().ToList();
                 {
                     var row = records[0] as IDictionary<string, object>;
-                    Assert.Equal(@"""<>+-*//}{\\n", row["1"]);
+                    Assert.Equal(@"""<>+-*//}{\\n", row!["1"]);
                     Assert.Equal("1234567890", row["2"]);
                     Assert.Equal("True", row["3"]);
                     Assert.Equal("2021-01-01 00:00:00", row["4"]);
                 }
                 {
                     var row = records[1] as IDictionary<string, object>;
-                    Assert.Equal("<test>Hello World</test>", row["1"]);
+                    Assert.Equal("<test>Hello World</test>", row!["1"]);
                     Assert.Equal("-1234567890", row["2"]);
                     Assert.Equal("False", row["3"]);
                     Assert.Equal("2021-01-02 00:00:00", row["4"]);
@@ -283,33 +283,27 @@ public class MiniExcelCsvTests
     [Fact]
     public void CsvExcelTypeTest()
     {
-        {
-            using var file = AutoDeletingPath.Create(ExcelType.CSV);
-            var path = file.ToString();
+        using var file = AutoDeletingPath.Create(ExcelType.CSV);
+        var path = file.ToString();
             
-            var input = new[] { new { A = "Test1", B = "Test2" } };
-            MiniExcel.SaveAs(path.ToString(), input);
+        var input = new[] { new { A = "Test1", B = "Test2" } };
+        MiniExcel.SaveAs(path, input);
 
-            var texts = File.ReadAllLines(path.ToString());
-            Assert.Equal("A,B", texts[0]);
-            Assert.Equal("Test1,Test2", texts[1]);
+        var texts = File.ReadAllLines(path);
+        Assert.Equal("A,B", texts[0]);
+        Assert.Equal("Test1,Test2", texts[1]);
 
-            {
-                var rows = MiniExcel.Query(path.ToString()).ToList();
-                Assert.Equal("A", rows[0].A);
-                Assert.Equal("B", rows[0].B);
-                Assert.Equal("Test1", rows[1].A);
-                Assert.Equal("Test2", rows[1].B);
-            }
+        var rows = MiniExcel.Query(path).ToList();
+        Assert.Equal("A", rows[0].A);
+        Assert.Equal("B", rows[0].B);
+        Assert.Equal("Test1", rows[1].A);
+        Assert.Equal("Test2", rows[1].B);
 
-            using var reader = new StreamReader(path.ToString());
-            using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-            {
-                var rows = csv.GetRecords<dynamic>().ToList();
-                Assert.Equal("Test1", rows[0].A);
-                Assert.Equal("Test2", rows[0].B);
-            }
-        }
+        using var reader = new StreamReader(path);
+        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+        var records = csv.GetRecords<dynamic>().ToList();
+        Assert.Equal("Test1", records[0].A);
+        Assert.Equal("Test2", records[0].B);
     }
 
     [Fact]
@@ -388,7 +382,7 @@ public class MiniExcelCsvTests
             Assert.Equal(2, exception.RowIndex);
             Assert.Null(exception.ColumnIndex);
             Assert.True(exception.RowValues is IDictionary<string, object>);
-            Assert.Equal(1, ((IDictionary<string, object>)exception.RowValues).Count);
+            Assert.Single((IDictionary<string, object>)exception.RowValues);
         }
 
         {
@@ -398,7 +392,7 @@ public class MiniExcelCsvTests
             Assert.Equal(2, exception.RowIndex);
             Assert.Null(exception.ColumnIndex);
             Assert.True(exception.RowValues is IDictionary<string, object>);
-            Assert.Equal(1, ((IDictionary<string, object>)exception.RowValues).Count);
+            Assert.Single((IDictionary<string, object>)exception.RowValues);
         }
     }
 
@@ -417,7 +411,7 @@ public class MiniExcelCsvTests
             Assert.Equal(2, exception.RowIndex);
             Assert.Null(exception.ColumnIndex);
             Assert.True(exception.RowValues is IDictionary<string, object>);
-            Assert.Equal(1, ((IDictionary<string, object>)exception.RowValues).Count);
+            Assert.Single((IDictionary<string, object>)exception.RowValues);
         }
 
         {
@@ -427,7 +421,7 @@ public class MiniExcelCsvTests
             Assert.Equal(2, exception.RowIndex);
             Assert.Null(exception.ColumnIndex);
             Assert.True(exception.RowValues is IDictionary<string, object>);
-            Assert.Equal(1, ((IDictionary<string, object>)exception.RowValues).Count);
+            Assert.Single((IDictionary<string, object>)exception.RowValues);
         }
     }
 

--- a/tests/MiniExcelTests/MiniExcelCsvTests.cs
+++ b/tests/MiniExcelTests/MiniExcelCsvTests.cs
@@ -60,6 +60,43 @@ public class MiniExcelCsvTests
             """";
         Assert.Equal(expected, File.ReadAllText(path));
     }
+    
+    [Fact]
+    public void DontQuoteWhitespacesTest()
+    {
+        using var file = AutoDeletingPath.Create(ExcelType.CSV);
+        var path = file.ToString();
+
+        List<Dictionary<string, object>> values =
+        [
+            new()
+            {
+                { "a", @"""<>+-*//}{\\n" },
+                { "b", 1234567890 },
+                { "c", true },
+                { "d", new DateTime(2021, 1, 1) }
+            },
+
+            new()
+            {
+                { "a", "<test>Hello World</test>" },
+                { "b", -1234567890 },
+                { "c", false },
+                { "d", new DateTime(2021, 1, 2) }
+            }
+        ];
+        var rowsWritten = MiniExcel.SaveAs(path, values, configuration: new Csv.CsvConfiguration { QuoteWhitespaces = false });
+        Assert.Equal(2, rowsWritten[0]);
+            
+        const string expected =
+            """"
+            a,b,c,d
+            """<>+-*//}{\\n",1234567890,True,2021-01-01 00:00:00
+            <test>Hello World</test>,-1234567890,False,2021-01-02 00:00:00
+
+            """";
+        Assert.Equal(expected, File.ReadAllText(path));
+    }
 
     [Fact]
     public void AlwaysQuoteTest()

--- a/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueAsyncTests.cs
@@ -186,7 +186,7 @@ public class MiniExcelIssueAsyncTests(ITestOutputHelper output)
         await Assert.ThrowsAsync<NotSupportedException>(async () => _ = (await MiniExcel.QueryAsync(path)).ToList());
 
         await using var stream = File.OpenRead(path);
-        await Assert.ThrowsAsync<NotSupportedException>(async () => _ = (await stream.QueryAsync()).ToList());
+        await Assert.ThrowsAsync<InvalidDataException>(async () => _ = (await stream.QueryAsync()).ToList());
     }
 
     /// <summary>

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -152,8 +152,8 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
         {
             var value = new[]
             {
-                new { ID=1,Name ="Jack",InDate=new DateTime(2021,01,03)},
-                new { ID=2,Name ="Henry",InDate=new DateTime(2020,05,03)},
+                new { ID = 1, Name = "Jack", InDate = new DateTime(2021,01,03)},
+                new { ID = 2, Name = "Henry", InDate = new DateTime(2020,05,03)}
             };
             MiniExcel.SaveAs(path, value);
             var content = File.ReadAllText(path);
@@ -2012,7 +2012,7 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
         Assert.Throws<NotSupportedException>(() => MiniExcel.Query(path).ToList());
 
         using var stream = File.OpenRead(path);
-        Assert.Throws<NotSupportedException>(() => stream.Query().ToList());
+        Assert.Throws<InvalidDataException>(() => stream.Query().ToList());
     }
 
     /// <summary>

--- a/tests/MiniExcelTests/Utils/PathHelper.cs
+++ b/tests/MiniExcelTests/Utils/PathHelper.cs
@@ -2,16 +2,13 @@
 
 internal static class PathHelper
 {
-    public static string GetFile(string fileName)
-    {
-        return $"../../../../../samples/{fileName}";
-    }
+    public static string GetFile(string fileName) => $"../../../../../samples/{fileName}";
 
     public static string GetTempPath(string extension = "xlsx")
     {
-        var method = new System.Diagnostics.StackTrace().GetFrame(1).GetMethod();
+        var method = new System.Diagnostics.StackTrace().GetFrame(1)?.GetMethod();
 
-        var path = Path.Combine(Path.GetTempPath(), $"{method.DeclaringType.Name}_{method.Name}.{extension}")
+        var path = Path.Combine(Path.GetTempPath(), $"{method?.DeclaringType?.Name}_{method?.Name}.{extension}")
             .Replace("<", string.Empty)
             .Replace(">", string.Empty);
         


### PR DESCRIPTION
- Resolves #652 by providing the option to add double quotes to values containing whitespaces in csv files through the new `CsvConfiguration` property `QuoteWhitespaces`. The option is activated by default to mantain backwards compatibility.
- Adds a test for the previous case
- Resolves #788 by fixing the benchmark workflow file and updating the dependencies to the other OpenXml manipulation libraries
- Fixes some minor warnings highlightened by CodeQL
- Minor refactoring and code cleanup