### PR TITLE
refactor(ExcelReader):  restructure the code

### DIFF
--- a/src/MiniExcel/Csv/CsvReader.cs
+++ b/src/MiniExcel/Csv/CsvReader.cs
@@ -15,7 +15,7 @@ namespace MiniExcelLibs.Csv
     {
         private Stream _stream;
         private CsvConfiguration _config;
-        
+
         public CsvReader(Stream stream, IConfiguration configuration)
         {
             _stream = stream;
@@ -28,7 +28,7 @@ namespace MiniExcelLibs.Csv
 
             if (_stream.CanSeek)
                 _stream.Position = 0;
- 
+
             var reader = _config.StreamReaderFunc(_stream);
             var firstRow = true;
             var headRows = new Dictionary<int, string>();
@@ -59,7 +59,7 @@ namespace MiniExcelLibs.Csv
                     var rowValues = read
                         .Select((x, i) => new KeyValuePair<string, object>(headRows[i], x))
                         .ToDictionary(x => x.Key, x => x.Value);
-                    
+
                     throw new ExcelColumnNotFoundException(columnIndex: null, headRows[colIndex], null, rowIndex, headers, rowValues, $"Csv read error: Column {colIndex} not found in Row {rowIndex}");
                 }
 
@@ -145,16 +145,16 @@ namespace MiniExcelLibs.Csv
         {
             if (startCell != "A1")
                 throw new NotImplementedException("CSV does not implement parameter startCell");
-            
+
             if (_stream.CanSeek)
                 _stream.Position = 0;
-            
+
             var reader = _config.StreamReaderFunc(_stream);
-            
+
             string row;
             var firstRow = true;
             var headRows = new Dictionary<int, string>();
-            
+
             while ((row = reader.ReadLine()) != null)
             {
                 var read = Split(row);
@@ -182,20 +182,20 @@ namespace MiniExcelLibs.Csv
                 var cell = CustomPropertyHelper.GetEmptyExpandoObject(read.Length - 1, 0);
                 for (int i = 0; i <= read.Length - 1; i++)
                     cell[ColumnHelper.GetAlphabetColumnName(i)] = read[i];
-                
+
                 yield return cell;
             }
         }
-        public IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCel) where T : class, new()
+        public IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new()
         {
-            return ExcelOpenXmlSheetReader.QueryImplRange<T>(QueryRange(false, sheetName, startCell, endCel), startCell, endCel, this._config);
+            return ExcelOpenXmlSheetReader.QueryImpl<T>(QueryRange(false, sheetName, startCell, endCell), startCell, hasHeader, this._config);
         }
-        public Task<IEnumerable<IDictionary<string, object>>> QueryAsyncRange(bool useHeaderRow, string sheetName, string startCell, string endCel, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCel, CancellationToken cancellationToken = default)
         {
             return Task.Run(() => QueryRange(useHeaderRow, sheetName, startCell, endCel), cancellationToken);
         }
 
-        public Task<IEnumerable<T>> QueryAsyncRange<T>(string sheetName, string startCell, string endCel, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
+        public Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCel, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
         {
             return Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken);
         }

--- a/src/MiniExcel/Csv/CsvReader.cs
+++ b/src/MiniExcel/Csv/CsvReader.cs
@@ -1,3 +1,4 @@
+using MiniExcelLibs.Exceptions;
 using MiniExcelLibs.OpenXml;
 using MiniExcelLibs.Utils;
 using System;
@@ -7,7 +8,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using MiniExcelLibs.Exceptions;
 
 namespace MiniExcelLibs.Csv
 {
@@ -21,6 +21,7 @@ namespace MiniExcelLibs.Csv
             _stream = stream;
             _config = configuration == null ? CsvConfiguration.DefaultConfiguration : (CsvConfiguration)configuration;
         }
+
         public IEnumerable<IDictionary<string, object>> Query(bool useHeaderRow, string sheetName, string startCell)
         {
             if (startCell != "A1")
@@ -105,10 +106,63 @@ namespace MiniExcelLibs.Csv
                 yield return cell;
             }
         }
+
         public IEnumerable<T> Query<T>(string sheetName, string startCell, bool hasHeader) where T : class, new()
         {
             var dynamicRecords = Query(false, sheetName, startCell);
             return ExcelOpenXmlSheetReader.QueryImpl<T>(dynamicRecords, startCell, hasHeader, _config);
+        }
+
+        public IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, string startCell, string endCell)
+        {
+            throw new NotImplementedException("CSV does not implement QueryRange");
+        }
+
+        public IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new()
+        {
+            var dynamicRecords = QueryRange(false, sheetName, startCell, endCell);
+            return ExcelOpenXmlSheetReader.QueryImpl<T>(dynamicRecords, startCell, hasHeader, this._config);
+        }
+
+        public IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex)
+        {
+            throw new NotImplementedException("CSV does not implement QueryRange");
+        }
+
+        public IEnumerable<T> QueryRange<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader) where T : class, new()
+        {
+            var dynamicRecords = QueryRange(false, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex);
+            return ExcelOpenXmlSheetReader.QueryImpl<T>(dynamicRecords, ReferenceHelper.ConvertXyToCell(startRowIndex, startColumnIndex), hasHeader, this._config);
+        }
+
+        public Task<IEnumerable<IDictionary<string, object>>> QueryAsync(bool useHeaderRow, string sheetName, string startCell, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken);
+        }
+
+        public async Task<IEnumerable<T>> QueryAsync<T>(string sheetName, string startCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCel, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => QueryRange(useHeaderRow, sheetName, startCell, endCel), cancellationToken);
+        }
+
+        public async Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCel, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => QueryRange<T>(sheetName, startCell, endCel, hasHeader), cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, CancellationToken cancellationToken = default)
+        {
+            return Task.Run(() => QueryRange(useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex), cancellationToken);
+        }
+
+        public async Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => QueryRange<T>(sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex, hasHeader), cancellationToken).ConfigureAwait(false);
         }
 
         private string[] Split(string row)
@@ -126,79 +180,8 @@ namespace MiniExcelLibs.Csv
             }
         }
 
-        public Task<IEnumerable<IDictionary<string, object>>> QueryAsync(bool useHeaderRow, string sheetName, string startCell, CancellationToken cancellationToken = default)
-        {
-            return Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken);
-        }
-
-        public Task<IEnumerable<T>> QueryAsync<T>(string sheetName, string startCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
-        {
-            return Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken);
-        }
-
         public void Dispose()
         {
         }
-
-        #region Range
-        public IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, string startCell, string endCell)
-        {
-            if (startCell != "A1")
-                throw new NotImplementedException("CSV does not implement parameter startCell");
-
-            if (_stream.CanSeek)
-                _stream.Position = 0;
-
-            var reader = _config.StreamReaderFunc(_stream);
-
-            string row;
-            var firstRow = true;
-            var headRows = new Dictionary<int, string>();
-
-            while ((row = reader.ReadLine()) != null)
-            {
-                var read = Split(row);
-
-                //header
-                if (useHeaderRow)
-                {
-                    if (firstRow)
-                    {
-                        firstRow = false;
-                        for (int i = 0; i <= read.Length - 1; i++)
-                            headRows.Add(i, read[i]);
-                        continue;
-                    }
-
-                    var headCell = CustomPropertyHelper.GetEmptyExpandoObject(headRows);
-                    for (int i = 0; i <= read.Length - 1; i++)
-                        headCell[headRows[i]] = read[i];
-
-                    yield return headCell;
-                    continue;
-                }
-
-                //body
-                var cell = CustomPropertyHelper.GetEmptyExpandoObject(read.Length - 1, 0);
-                for (int i = 0; i <= read.Length - 1; i++)
-                    cell[ColumnHelper.GetAlphabetColumnName(i)] = read[i];
-
-                yield return cell;
-            }
-        }
-        public IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new()
-        {
-            return ExcelOpenXmlSheetReader.QueryImpl<T>(QueryRange(false, sheetName, startCell, endCell), startCell, hasHeader, this._config);
-        }
-        public Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCel, CancellationToken cancellationToken = default)
-        {
-            return Task.Run(() => QueryRange(useHeaderRow, sheetName, startCell, endCel), cancellationToken);
-        }
-
-        public Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCel, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new()
-        {
-            return Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken);
-        }
-        #endregion
     }
 }

--- a/src/MiniExcel/IExcelReader.cs
+++ b/src/MiniExcel/IExcelReader.cs
@@ -12,8 +12,8 @@ namespace MiniExcelLibs
         Task<IEnumerable<IDictionary<string, object>>> QueryAsync(bool useHeaderRow, string sheetName, string startCell, CancellationToken cancellationToken = default);
         Task<IEnumerable<T>> QueryAsync<T>(string sheetName, string startCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new();
         IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, string startCell, string endCell);
-        IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell) where T : class, new();
-        Task<IEnumerable<IDictionary<string, object>>> QueryAsyncRange(bool useHeaderRow, string sheetName, string startCell, string endCell, CancellationToken cancellationToken = default);
-        Task<IEnumerable<T>> QueryAsyncRange<T>(string sheetName, string startCell, string endCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new();
+        IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new();
+        Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCell, CancellationToken cancellationToken = default);
+        Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new();
     }
 }

--- a/src/MiniExcel/IExcelReader.cs
+++ b/src/MiniExcel/IExcelReader.cs
@@ -15,5 +15,9 @@ namespace MiniExcelLibs
         IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new();
         Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCell, CancellationToken cancellationToken = default);
         Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCell, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new();
+        IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex);
+        IEnumerable<T> QueryRange<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader) where T : class, new();
+        Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, CancellationToken cancellationToken = default);
+        Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader, CancellationToken cancellationToken = default) where T : class, new();
     }
 }

--- a/src/MiniExcel/MiniExcel.cs
+++ b/src/MiniExcel/MiniExcel.cs
@@ -102,12 +102,14 @@ namespace MiniExcelLibs
                 foreach (var item in excelReader.Query<T>(sheetName, startCell, hasHeader))
                     yield return item;
         }
+       
         public static IEnumerable<dynamic> Query(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", IConfiguration configuration = null)
         {
             using (var stream = FileHelper.OpenSharedRead(path))
                 foreach (var item in Query(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startCell, configuration))
                     yield return item;
         }
+        
         public static IEnumerable<dynamic> Query(this Stream stream, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", IConfiguration configuration = null)
         {
             using (var excelReader = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration))
@@ -116,7 +118,7 @@ namespace MiniExcelLibs
                             (dict, p) => { dict.Add(p); return dict; });
         }
 
-        #region range
+        #region QueryRange
 
         /// <summary>
         /// Extract the given range。 Only uppercase letters are effective。
@@ -136,19 +138,34 @@ namespace MiniExcelLibs
         public static IEnumerable<dynamic> QueryRange(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", string endCell = "", IConfiguration configuration = null)
         {
             using (var stream = FileHelper.OpenSharedRead(path))
-                foreach (var item in QueryRange(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startCell == "" ? "A1" : startCell, endCell, configuration))
+                foreach (var item in QueryRange(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startCell, endCell, configuration))
                     yield return item;
         }
 
         public static IEnumerable<dynamic> QueryRange(this Stream stream, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", string endCell = "", IConfiguration configuration = null)
         {
             using (var excelReader = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration))
-                foreach (var item in excelReader.QueryRange(useHeaderRow, sheetName, startCell == "" ? "A1" : startCell, endCell))
+                foreach (var item in excelReader.QueryRange(useHeaderRow, sheetName, startCell, endCell))
                     yield return item.Aggregate(new ExpandoObject() as IDictionary<string, object>,
                             (dict, p) => { dict.Add(p); return dict; });
         }
 
-        #endregion range
+        public static IEnumerable<dynamic> QueryRange(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, int startRowIndex = 1, int startColumnIndex = 1, int? endRowIndex = null, int? endColumnIndex = null, IConfiguration configuration = null)
+        {
+            using (var stream = FileHelper.OpenSharedRead(path))
+                foreach (var item in QueryRange(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startRowIndex, startColumnIndex, endRowIndex, endColumnIndex, configuration))
+                    yield return item;
+        }
+        
+        public static IEnumerable<dynamic> QueryRange(this Stream stream, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, int startRowIndex = 1, int startColumnIndex = 1, int? endRowIndex = null, int? endColumnIndex = null, IConfiguration configuration = null)
+        {
+            using (var excelReader = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration))
+                foreach (var item in excelReader.QueryRange(useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex))
+                    yield return item.Aggregate(new ExpandoObject() as IDictionary<string, object>,
+                            (dict, p) => { dict.Add(p); return dict; });
+        }
+
+        #endregion QueryRange
 
         public static void SaveAsByTemplate(string path, string templatePath, object value, IConfiguration configuration = null)
         {

--- a/src/MiniExcel/MiniExcel.cs
+++ b/src/MiniExcel/MiniExcel.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿using MiniExcelLibs.OpenXml;
+using MiniExcelLibs.OpenXml.Models;
+using MiniExcelLibs.Picture;
+using MiniExcelLibs.Utils;
+using MiniExcelLibs.Zip;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
-using MiniExcelLibs.OpenXml;
-using MiniExcelLibs.OpenXml.Models;
-using MiniExcelLibs.Picture;
-using MiniExcelLibs.Utils;
-using MiniExcelLibs.Zip;
 
 namespace MiniExcelLibs
 {
@@ -17,15 +17,15 @@ namespace MiniExcelLibs
     {
         public static void AddPicture(string path, params MiniExcelPicture[] images)
         {
-            using (var stream = File.Open(path,FileMode.OpenOrCreate))
+            using (var stream = File.Open(path, FileMode.OpenOrCreate))
                 MiniExcelPictureImplement.AddPicture(stream, images);
         }
-        
+
         public static void AddPicture(Stream excelStream, params MiniExcelPicture[] images)
         {
             MiniExcelPictureImplement.AddPicture(excelStream, images);
         }
-        
+
         public static MiniExcelDataReader GetReader(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", IConfiguration configuration = null)
         {
             var stream = FileHelper.OpenSharedRead(path);
@@ -65,14 +65,14 @@ namespace MiniExcelLibs
             stream.Seek(0, SeekOrigin.End);
             if (excelType == ExcelType.CSV)
             {
-                var newValue = value is IEnumerable || value is IDataReader ? value : new[]{value};
+                var newValue = value is IEnumerable || value is IDataReader ? value : new[] { value };
                 return ExcelWriterFactory.GetProvider(stream, newValue, sheetName, excelType, configuration, false).Insert(overwriteSheet);
             }
             else
             {
                 var configOrDefault = configuration ?? new OpenXmlConfiguration { FastMode = true };
                 return ExcelWriterFactory.GetProvider(stream, value, sheetName, excelType, configOrDefault, printHeader).Insert(overwriteSheet);
-            } 
+            }
         }
 
         public static int[] SaveAs(string path, object value, bool printHeader = true, string sheetName = "Sheet1", ExcelType excelType = ExcelType.UNKNOWN, IConfiguration configuration = null, bool overwriteFile = false)
@@ -133,17 +133,17 @@ namespace MiniExcelLibs
         /// <param name="endCell">lower right corner</param>
         /// <param name="configuration"></param>
         /// <returns></returns>
-        public static IEnumerable<dynamic> QueryRange(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "a1", string endCell = "", IConfiguration configuration = null)
+        public static IEnumerable<dynamic> QueryRange(string path, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", string endCell = "", IConfiguration configuration = null)
         {
             using (var stream = FileHelper.OpenSharedRead(path))
-                foreach (var item in QueryRange(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startCell == "" ? "a1" : startCell, endCell, configuration))
+                foreach (var item in QueryRange(stream, useHeaderRow, sheetName, ExcelTypeHelper.GetExcelType(path, excelType), startCell == "" ? "A1" : startCell, endCell, configuration))
                     yield return item;
         }
 
-        public static IEnumerable<dynamic> QueryRange(this Stream stream, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "a1", string endCell = "", IConfiguration configuration = null)
+        public static IEnumerable<dynamic> QueryRange(this Stream stream, bool useHeaderRow = false, string sheetName = null, ExcelType excelType = ExcelType.UNKNOWN, string startCell = "A1", string endCell = "", IConfiguration configuration = null)
         {
             using (var excelReader = ExcelReaderFactory.GetProvider(stream, ExcelTypeHelper.GetExcelType(stream, excelType), configuration))
-                foreach (var item in excelReader.QueryRange(useHeaderRow, sheetName, startCell == "" ? "a1" : startCell, endCell))
+                foreach (var item in excelReader.QueryRange(useHeaderRow, sheetName, startCell == "" ? "A1" : startCell, endCell))
                     yield return item.Aggregate(new ExpandoObject() as IDictionary<string, object>,
                             (dict, p) => { dict.Add(p); return dict; });
         }
@@ -287,7 +287,7 @@ namespace MiniExcelLibs
         {
             return (Query(stream, useHeaderRow, sheetName, excelType, startCell, configuration).FirstOrDefault() as IDictionary<string, object>)?.Keys;
         }
-        
+
         public static IList<ExcelRange> GetSheetDimensions(string path)
         {
             using (var stream = FileHelper.OpenSharedRead(path))
@@ -298,7 +298,7 @@ namespace MiniExcelLibs
         {
             return new ExcelOpenXmlSheetReader(stream, null).GetDimensions();
         }
-        
+
         public static void ConvertCsvToXlsx(string csv, string xlsx)
         {
             using (var csvStream = FileHelper.OpenSharedRead(csv))

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.Async.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.Async.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MiniExcelLibs.OpenXml
+{
+    internal partial class ExcelOpenXmlSheetReader : IExcelReader
+    {
+        public async Task<IEnumerable<IDictionary<string, object>>> QueryAsync(bool useHeaderRow, string sheetName, string startCell, CancellationToken cancellationToken = default)
+        {
+            return await Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<T>> QueryAsync<T>(string sheetName, string startCell, bool hasHeader = true, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCell, CancellationToken cancellationToken = default)
+        {
+            return await Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCell, bool hasHeader = true, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => QueryRange<T>(sheetName, startCell, endCell, hasHeader), cancellationToken).ConfigureAwait(false);
+        }
+               
+        public async Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, CancellationToken cancellationToken = default)
+        {
+            return await Task.Run(() => QueryRange(useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex), cancellationToken).ConfigureAwait(false);
+        }
+        
+        public async Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader = true, CancellationToken cancellationToken = default) where T : class, new()
+        {
+            return await Task.Run(() => QueryRange<T>(sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex, hasHeader), cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -14,7 +14,7 @@ using System.Xml;
 
 namespace MiniExcelLibs.OpenXml
 {
-    internal class ExcelOpenXmlSheetReader : IExcelReader
+    internal partial class ExcelOpenXmlSheetReader : IExcelReader
     {
         private bool _disposed = false;
         private static readonly string[] _ns = { Config.SpreadsheetmlXmlns, Config.SpreadsheetmlXmlStrictns };
@@ -43,348 +43,6 @@ namespace MiniExcelLibs.OpenXml
         public IEnumerable<IDictionary<string, object>> Query(bool useHeaderRow, string sheetName, string startCell)
         {
             return QueryRange(useHeaderRow, sheetName, startCell, "");
-            //if (!ReferenceHelper.TryParseReference(startCell, out var startColumnIndex, out var startRowIndex))
-            //    throw new ArgumentException($"Value {startCell} is not a valid cell reference.");
-
-            //startColumnIndex--;
-            //startRowIndex--;
-
-            //// if sheets count > 1 need to read xl/_rels/workbook.xml.rels
-            //var sheets = _archive.entries
-            //    .Where(w => w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
-            //                w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
-            //    ).ToArray();
-
-            //ZipArchiveEntry sheetEntry;
-            //if (sheetName != null)
-            //{
-            //    SetWorkbookRels(_archive.entries);
-            //    var sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetName);
-            //    if (sheetRecord == null)
-            //    {
-            //        if (_config.DynamicSheets == null)
-            //            throw new InvalidOperationException("Please check that parameters sheetName/Index are correct");
-
-            //        var sheetConfig = _config.DynamicSheets.FirstOrDefault(ds => ds.Key == sheetName);
-            //        if (sheetConfig != null)
-            //        {
-            //            sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetConfig.Name);
-            //        }
-            //    }
-
-            //    sheetEntry = sheets.Single(w => w.FullName == $"xl/{sheetRecord.Path}" ||
-            //                                    w.FullName == $"/xl/{sheetRecord.Path}" ||
-            //                                    w.FullName == sheetRecord.Path ||
-            //                                    $"/{w.FullName}" == sheetRecord.Path);
-            //}
-            //else if (sheets.Length > 1)
-            //{
-            //    SetWorkbookRels(_archive.entries);
-            //    var s = _sheetRecords[0];
-            //    sheetEntry = sheets.Single(w => w.FullName == $"xl/{s.Path}" ||
-            //                                    w.FullName == $"/xl/{s.Path}" ||
-            //                                    w.FullName.TrimStart('/') == s.Path.TrimStart('/'));
-            //}
-            //else
-            //{
-            //    sheetEntry = sheets.Single();
-            //}
-
-            //#region MergeCells
-
-            //if (_config.FillMergedCells)
-            //{
-            //    _mergeCells = new MergeCells();
-            //    using (var sheetStream = sheetEntry.Open())
-            //    using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            //    {
-            //        if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
-            //            yield break;
-
-            //        while (reader.Read())
-            //        {
-            //            if (!XmlReaderHelper.IsStartElement(reader, "mergeCells", _ns))
-            //                continue;
-
-            //            if (!XmlReaderHelper.ReadFirstContent(reader))
-            //                yield break;
-
-            //            while (!reader.EOF)
-            //            {
-            //                if (XmlReaderHelper.IsStartElement(reader, "mergeCell", _ns))
-            //                {
-            //                    var refAttr = reader.GetAttribute("ref");
-            //                    var refs = refAttr.Split(':');
-            //                    if (refs.Length == 1)
-            //                        continue;
-
-            //                    ReferenceHelper.TryParseReference(refs[0], out var x1, out var y1);
-            //                    ReferenceHelper.TryParseReference(refs[1], out var x2, out var y2);
-
-            //                    _mergeCells.MergesValues.Add(refs[0], null);
-
-            //                    // foreach range
-            //                    var isFirst = true;
-            //                    for (int x = x1; x <= x2; x++)
-            //                    {
-            //                        for (int y = y1; y <= y2; y++)
-            //                        {
-            //                            if (!isFirst)
-            //                            {
-            //                                _mergeCells.MergesMap.Add(ReferenceHelper.ConvertXyToCell(x, y), refs[0]);
-            //                            }
-            //                            isFirst = false;
-            //                        }
-            //                    }
-
-            //                    XmlReaderHelper.SkipContent(reader);
-            //                }
-            //                else if (!XmlReaderHelper.SkipContent(reader))
-            //                {
-            //                    break;
-            //                }
-            //            }
-            //        }
-            //    }
-            //}
-
-            //#endregion MergeCells
-
-            //// TODO: need to optimize performance
-            //var withoutCR = false;
-            //var maxRowIndex = -1;
-            //var maxColumnIndex = -1;
-
-            ////Q. why need 3 times openstream merge one open read? A. no, zipstream can't use position = 0
-            //using (var sheetStream = sheetEntry.Open())
-            //using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            //{
-            //    while (reader.Read())
-            //    {
-            //        if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
-            //        {
-            //            var r = reader.GetAttribute("r");
-            //            if (r != null)
-            //            {
-            //                if (ReferenceHelper.TryParseReference(r, out var column, out var row))
-            //                {
-            //                    column--;
-            //                    row--;
-            //                    maxRowIndex = Math.Max(maxRowIndex, row);
-            //                    maxColumnIndex = Math.Max(maxColumnIndex, column);
-            //                }
-            //            }
-            //            else
-            //            {
-            //                withoutCR = true;
-            //                break;
-            //            }
-            //        }
-            //        //this method logic depends on dimension to get maxcolumnIndex, if without dimension then it need to foreach all rows first time to get maxColumn and maxRowColumn
-            //        else if (XmlReaderHelper.IsStartElement(reader, "dimension", _ns))
-            //        {
-            //            var refAttr = reader.GetAttribute("ref");
-            //            if (string.IsNullOrEmpty(refAttr))
-            //                throw new InvalidDataException("No dimension data found for the sheet");
-
-            //            var rs = refAttr.Split(':');
-
-            //            // issue : https://github.com/mini-software/MiniExcel/issues/102
-            //            if (!ReferenceHelper.TryParseReference(rs.Length == 2 ? rs[1] : rs[0], out int cIndex, out int rIndex))
-            //                throw new InvalidDataException("The dimensions of the sheet are invalid");
-
-            //            maxColumnIndex = cIndex - 1;
-            //            maxRowIndex = rIndex - 1;
-            //            break;
-            //        }
-            //    }
-            //}
-
-            //if (withoutCR)
-            //{
-            //    using (var sheetStream = sheetEntry.Open())
-            //    using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            //    {
-            //        if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
-            //            yield break;
-
-            //        if (!XmlReaderHelper.ReadFirstContent(reader))
-            //            yield break;
-
-            //        while (!reader.EOF)
-            //        {
-            //            if (XmlReaderHelper.IsStartElement(reader, "sheetData", _ns))
-            //            {
-            //                if (!XmlReaderHelper.ReadFirstContent(reader))
-            //                    continue;
-
-            //                while (!reader.EOF)
-            //                {
-            //                    if (XmlReaderHelper.IsStartElement(reader, "row", _ns))
-            //                    {
-            //                        maxRowIndex++;
-
-            //                        if (!XmlReaderHelper.ReadFirstContent(reader))
-            //                            continue;
-
-            //                        // Cells
-            //                        var cellIndex = -1;
-            //                        while (!reader.EOF)
-            //                        {
-            //                            if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
-            //                            {
-            //                                cellIndex++;
-            //                                maxColumnIndex = Math.Max(maxColumnIndex, cellIndex);
-            //                            }
-
-            //                            if (!XmlReaderHelper.SkipContent(reader))
-            //                                break;
-            //                        }
-            //                    }
-            //                    else if (!XmlReaderHelper.SkipContent(reader))
-            //                    {
-            //                        break;
-            //                    }
-            //                }
-            //            }
-            //            else if (!XmlReaderHelper.SkipContent(reader))
-            //            {
-            //                break;
-            //            }
-            //        }
-            //    }
-            //}
-
-            //using (var sheetStream = sheetEntry.Open())
-            //using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            //{
-            //    if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
-            //        yield break;
-
-            //    if (!XmlReaderHelper.ReadFirstContent(reader))
-            //        yield break;
-
-            //    while (!reader.EOF)
-            //    {
-            //        if (XmlReaderHelper.IsStartElement(reader, "sheetData", _ns))
-            //        {
-            //            if (!XmlReaderHelper.ReadFirstContent(reader))
-            //                continue;
-
-            //            var headRows = new Dictionary<int, string>();
-            //            var rowIndex = -1;
-            //            var isFirstRow = true;
-            //            while (!reader.EOF)
-            //            {
-            //                if (XmlReaderHelper.IsStartElement(reader, "row", _ns))
-            //                {
-            //                    var nextRowIndex = rowIndex + 1;
-            //                    if (int.TryParse(reader.GetAttribute("r"), out int arValue))
-            //                        rowIndex = arValue - 1; // The row attribute is 1-based
-            //                    else
-            //                        rowIndex++;
-
-            //                    // row -> c
-            //                    if (!XmlReaderHelper.ReadFirstContent(reader))
-            //                    {
-            //                        //Fill in case of self closed empty row tag eg. <row r="1"/>
-            //                        yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-            //                        continue;
-            //                    }
-
-            //                    // startcell pass rows
-            //                    if (rowIndex < startRowIndex)
-            //                    {
-            //                        XmlReaderHelper.SkipToNextSameLevelDom(reader);
-            //                        continue;
-            //                    }
-
-            //                    // fill empty rows
-            //                    if (!_config.IgnoreEmptyRows)
-            //                    {
-            //                        var expectedRowIndex = isFirstRow ? startRowIndex : nextRowIndex;
-            //                        if (startRowIndex <= expectedRowIndex && expectedRowIndex < rowIndex)
-            //                        {
-            //                            for (int i = expectedRowIndex; i < rowIndex; i++)
-            //                            {
-            //                                yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-            //                            }
-            //                        }
-            //                    }
-
-            //                    #region Set Cells
-
-            //                    var cell = GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-            //                    var columnIndex = withoutCR ? -1 : 0;
-
-            //                    while (!reader.EOF)
-            //                    {
-            //                        if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
-            //                        {
-            //                            var aS = reader.GetAttribute("s");
-            //                            var aR = reader.GetAttribute("r");
-            //                            var aT = reader.GetAttribute("t");
-            //                            var cellValue = ReadCellAndSetColumnIndex(reader, ref columnIndex, withoutCR, startColumnIndex, aR, aT);
-
-            //                            if (_config.FillMergedCells)
-            //                            {
-            //                                if (_mergeCells.MergesValues.ContainsKey(aR))
-            //                                {
-            //                                    _mergeCells.MergesValues[aR] = cellValue;
-            //                                }
-            //                                else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
-            //                                {
-            //                                    _mergeCells.MergesValues.TryGetValue(mergeKey, out cellValue);
-            //                                }
-            //                            }
-
-            //                            if (columnIndex < startColumnIndex)
-            //                                continue;
-
-            //                            // if c with s meaning is custom style need to check type by xl/style.xml
-            //                            if (!string.IsNullOrEmpty(aS))
-            //                            {
-            //                                int xfIndex = -1;
-            //                                if (int.TryParse(aS, NumberStyles.Any, CultureInfo.InvariantCulture, out var styleIndex))
-            //                                    xfIndex = styleIndex;
-
-            //                                // only when have s attribute then load styles xml data
-            //                                if (_style == null)
-            //                                    _style = new ExcelOpenXmlStyles(_archive);
-
-            //                                cellValue = _style.ConvertValueByStyleFormat(xfIndex, cellValue);
-            //                            }
-            //                            SetCellsValueAndHeaders(cellValue, useHeaderRow, ref headRows, ref isFirstRow, ref cell, columnIndex);
-            //                        }
-            //                        else if (!XmlReaderHelper.SkipContent(reader))
-            //                        {
-            //                            break;
-            //                        }
-            //                    }
-
-            //                    #endregion
-
-            //                    if (isFirstRow)
-            //                    {
-            //                        isFirstRow = false; // for startcell logic
-            //                        if (useHeaderRow)
-            //                            continue;
-            //                    }
-
-            //                    yield return cell;
-            //                }
-            //                else if (!XmlReaderHelper.SkipContent(reader))
-            //                {
-            //                    break;
-            //                }
-            //            }
-            //        }
-            //        else if (!XmlReaderHelper.SkipContent(reader))
-            //        {
-            //            break;
-            //        }
-            //    }
-            //}
         }
 
         public IEnumerable<T> Query<T>(string sheetName, string startCell, bool hasHeader) where T : class, new()
@@ -397,22 +55,13 @@ namespace MiniExcelLibs.OpenXml
             return QueryImpl<T>(Query(false, sheetName, startCell), startCell, hasHeader, _config);
         }
 
-        public async Task<IEnumerable<IDictionary<string, object>>> QueryAsync(bool useHeaderRow, string sheetName, string startCell, CancellationToken cancellationToken = default)
-        {
-            return await Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<IEnumerable<T>> QueryAsync<T>(string sheetName, string startCell, bool hasHeader = true, CancellationToken cancellationToken = default) where T : class, new()
-        {
-            return await Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken).ConfigureAwait(false);
-        }
-
         public IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, string startCell, string endCell)
         {
-            if (!ReferenceHelper.TryParseReference(startCell, out var startColumnIndex, out var startRowIndex))
+            if (!ReferenceHelper.ParseReference(startCell, out var startColumnIndex, out var startRowIndex))
             {
                 throw new InvalidDataException($"Value {startCell} is not a valid cell reference.");
             }
+            // convert to 0-based
             startColumnIndex--;
             startRowIndex--;
 
@@ -421,426 +70,252 @@ namespace MiniExcelLibs.OpenXml
             int? endRowIndex = null;
             if (!string.IsNullOrWhiteSpace(endCell))
             {
-                if (!ReferenceHelper.TryParseReference(endCell, out int cIndex, out int rIndex))
+                if (!ReferenceHelper.ParseReference(endCell, out int cIndex, out int rIndex))
                 {
                     throw new InvalidDataException($"Value {endCell} is not a valid cell reference.");
                 }
+
+                // convert to 0-based
                 endColumnIndex = cIndex - 1;
                 endRowIndex = rIndex - 1;
             }
 
-            // if sheets count > 1 need to read xl/_rels/workbook.xml.rels
-            var sheets = _archive.entries
-                .Where(w => w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-            ZipArchiveEntry sheetEntry = null;
-            if (sheetName != null)
-            {
-                SetWorkbookRels(_archive.entries);
-                var sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetName);
-                if (sheetRecord == null)
-                {
-                    if (_config.DynamicSheets == null)
-                        throw new InvalidOperationException("Please check that parameters sheetName/Index are correct");
-
-                    var sheetConfig = _config.DynamicSheets.FirstOrDefault(ds => ds.Key == sheetName);
-                    if (sheetConfig != null)
-                    {
-                        sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetConfig.Name);
-                    }
-                }
-                sheetEntry = sheets.Single(w => w.FullName == $"xl/{sheetRecord.Path}" || w.FullName == $"/xl/{sheetRecord.Path}" || w.FullName == sheetRecord.Path || sheetRecord.Path == $"/{w.FullName}");
-            }
-            else if (sheets.Length > 1)
-            {
-                SetWorkbookRels(_archive.entries);
-                var s = _sheetRecords[0];
-                sheetEntry = sheets.Single(w => w.FullName == $"xl/{s.Path}" || w.FullName == $"/xl/{s.Path}" || w.FullName.TrimStart('/') == s.Path.TrimStart('/'));
-            }
-            else
-                sheetEntry = sheets.Single();
-
-            // TODO: need to optimize performance
-            // Q. why need 3 times openstream merge one open read? A. no, zipstream can't use position = 0
-
-            if (_config.FillMergedCells)
-            {
-                if (!TryGetMergeCells(sheetEntry, out _mergeCells))
-                {
-                    yield break;
-                }
-            }
-
-            if (!TryGetMaxRowColumnIndex(sheetEntry, out var withoutCR, out var maxRowIndex, out var maxColumnIndex))
-            {
-                yield break;
-            }
-
-            if (endColumnIndex.HasValue)
-            {
-                maxColumnIndex = endColumnIndex.Value;
-            }
-
-            using (var sheetStream = sheetEntry.Open())
-            using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            {
-                if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
-                    yield break;
-
-                if (!XmlReaderHelper.ReadFirstContent(reader))
-                    yield break;
-
-                while (!reader.EOF)
-                {
-                    if (XmlReaderHelper.IsStartElement(reader, "sheetData", _ns))
-                    {
-                        if (!XmlReaderHelper.ReadFirstContent(reader))
-                            continue;
-
-                        var headRows = new Dictionary<int, string>();
-                        int rowIndex = -1;
-                        bool isFirstRow = true;
-                        while (!reader.EOF)
-                        {
-                            if (XmlReaderHelper.IsStartElement(reader, "row", _ns))
-                            {
-                                var nextRowIndex = rowIndex + 1;
-                                if (int.TryParse(reader.GetAttribute("r"), out int arValue))
-                                    rowIndex = arValue - 1; // The row attribute is 1-based
-                                else
-                                    rowIndex++;
-
-                                if (rowIndex < startRowIndex)
-                                {
-                                    XmlReaderHelper.ReadFirstContent(reader);
-                                    XmlReaderHelper.SkipToNextSameLevelDom(reader);
-                                    continue;
-                                }
-                                if (endRowIndex.HasValue && rowIndex > endRowIndex.Value)
-                                {
-                                    break;
-                                }
-
-                                // fill empty rows
-                                if (!_config.IgnoreEmptyRows)
-                                {
-                                    var expectedRowIndex = isFirstRow ? startRowIndex : nextRowIndex;
-                                    if (startRowIndex <= expectedRowIndex && expectedRowIndex < rowIndex)
-                                    {
-                                        for (int i = expectedRowIndex; i < rowIndex; i++)
-                                        {
-                                            yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                        }
-                                    }
-                                }
-
-                                // row -> c, must after `if (nextRowIndex < rowIndex)` condition code, eg. The first empty row has no xml element,and the second row xml element is <row r="2"/>
-                                if (!XmlReaderHelper.ReadFirstContent(reader) && !_config.IgnoreEmptyRows)
-                                {
-                                    //Fill in case of self closed empty row tag eg. <row r="1"/>
-                                    yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                    continue;
-                                }
-
-                                #region Set Cells
-
-                                var cell = GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                var columnIndex = withoutCR ? -1 : 0;
-                                while (!reader.EOF)
-                                {
-                                    if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
-                                    {
-                                        var aS = reader.GetAttribute("s");
-                                        var aR = reader.GetAttribute("r");
-                                        var aT = reader.GetAttribute("t");
-                                        var cellValue = ReadCellAndSetColumnIndex(reader, ref columnIndex, withoutCR,
-                                            startColumnIndex, aR, aT);
-
-                                        if (_config.FillMergedCells)
-                                        {
-                                            if (_mergeCells.MergesValues.ContainsKey(aR))
-                                            {
-                                                _mergeCells.MergesValues[aR] = cellValue;
-                                            }
-                                            else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
-                                            {
-                                                _mergeCells.MergesValues.TryGetValue(mergeKey, out cellValue);
-                                            }
-                                        }
-
-                                        if (columnIndex < startColumnIndex || (endColumnIndex.HasValue && columnIndex > endColumnIndex.Value))
-                                            continue;
-
-                                        if (!string.IsNullOrEmpty(aS)) // if c with s meaning is custom style need to check type by xl/style.xml
-                                        {
-                                            int xfIndex = -1;
-                                            if (int.TryParse(aS, NumberStyles.Any, CultureInfo.InvariantCulture,
-                                                    out var styleIndex))
-                                                xfIndex = styleIndex;
-
-                                            // only when have s attribute then load styles xml data
-                                            if (_style == null)
-                                                _style = new ExcelOpenXmlStyles(_archive);
-
-                                            cellValue = _style.ConvertValueByStyleFormat(xfIndex, cellValue);
-                                        }
-
-                                        SetCellsValueAndHeaders(cellValue, useHeaderRow, ref headRows, ref isFirstRow, ref cell, columnIndex);
-                                    }
-                                    else if (!XmlReaderHelper.SkipContent(reader))
-                                        break;
-                                }
-
-                                #endregion
-
-                                if (isFirstRow)
-                                {
-                                    isFirstRow = false; // for startcell logic
-                                    if (useHeaderRow)
-                                        continue;
-                                }
-
-                                yield return cell;
-                            }
-                            else if (!XmlReaderHelper.SkipContent(reader))
-                            {
-                                break;
-                            }
-                        }
-                    }
-                    else if (!XmlReaderHelper.SkipContent(reader))
-                    {
-                        break;
-                    }
-                }
-            }
+            return InternalQueryRange(useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex);
         }
-
-#if NETSTANDARD2_0_OR_GREATER || NET
-        public async IAsyncEnumerable<IDictionary<string, object>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCell)
-        {
-            if (!ReferenceHelper.TryParseReference(startCell, out var startColumnIndex, out var startRowIndex))
-            {
-                throw new InvalidDataException($"Value {startCell} is not a valid cell reference.");
-            }
-            startColumnIndex--;
-            startRowIndex--;
-
-            // endCell is allowed to be empty to query for all rows and columns
-            int? endColumnIndex = null;
-            int? endRowIndex = null;
-            if (!string.IsNullOrWhiteSpace(endCell))
-            {
-                if (!ReferenceHelper.TryParseReference(endCell, out int cIndex, out int rIndex))
-                {
-                    throw new InvalidDataException($"Value {endCell} is not a valid cell reference.");
-                }
-                endColumnIndex = cIndex - 1;
-                endRowIndex = rIndex - 1;
-            }
-
-            // if sheets count > 1 need to read xl/_rels/workbook.xml.rels
-            var sheets = _archive.entries
-                .Where(w => w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-            ZipArchiveEntry sheetEntry = null;
-            if (sheetName != null)
-            {
-                SetWorkbookRels(_archive.entries);
-                var sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetName);
-                if (sheetRecord == null)
-                {
-                    if (_config.DynamicSheets == null)
-                        throw new InvalidOperationException("Please check that parameters sheetName/Index are correct");
-
-                    var sheetConfig = _config.DynamicSheets.FirstOrDefault(ds => ds.Key == sheetName);
-                    if (sheetConfig != null)
-                    {
-                        sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetConfig.Name);
-                    }
-                }
-                sheetEntry = sheets.Single(w => w.FullName == $"xl/{sheetRecord.Path}" || w.FullName == $"/xl/{sheetRecord.Path}" || w.FullName == sheetRecord.Path || sheetRecord.Path == $"/{w.FullName}");
-            }
-            else if (sheets.Length > 1)
-            {
-                SetWorkbookRels(_archive.entries);
-                var s = _sheetRecords[0];
-                sheetEntry = sheets.Single(w => w.FullName == $"xl/{s.Path}" || w.FullName == $"/xl/{s.Path}" || w.FullName.TrimStart('/') == s.Path.TrimStart('/'));
-            }
-            else
-                sheetEntry = sheets.Single();
-
-            // TODO: need to optimize performance
-            // Q. why need 3 times openstream merge one open read? A. no, zipstream can't use position = 0
-
-            if (_config.FillMergedCells)
-            {
-                if (!TryGetMergeCells(sheetEntry, out _mergeCells))
-                {
-                    yield break;
-                }
-            }
-
-            if (!TryGetMaxRowColumnIndex(sheetEntry, out var withoutCR, out var maxRowIndex, out var maxColumnIndex))
-            {
-                yield break;
-            }
-
-            if (endColumnIndex.HasValue)
-            {
-                maxColumnIndex = endColumnIndex.Value;
-            }
-
-            using (var sheetStream = sheetEntry.Open())
-            using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
-            {
-                if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
-                    yield break;
-
-                if (!XmlReaderHelper.ReadFirstContent(reader))
-                    yield break;
-
-                while (!reader.EOF)
-                {
-                    if (XmlReaderHelper.IsStartElement(reader, "sheetData", _ns))
-                    {
-                        if (!XmlReaderHelper.ReadFirstContent(reader))
-                            continue;
-
-                        var headRows = new Dictionary<int, string>();
-                        int rowIndex = -1;
-                        bool isFirstRow = true;
-                        while (!reader.EOF)
-                        {
-                            if (XmlReaderHelper.IsStartElement(reader, "row", _ns))
-                            {
-                                var nextRowIndex = rowIndex + 1;
-                                if (int.TryParse(reader.GetAttribute("r"), out int arValue))
-                                    rowIndex = arValue - 1; // The row attribute is 1-based
-                                else
-                                    rowIndex++;
-
-                                if (rowIndex < startRowIndex)
-                                {
-                                    XmlReaderHelper.ReadFirstContent(reader);
-                                    XmlReaderHelper.SkipToNextSameLevelDom(reader);
-                                    continue;
-                                }
-                                if (endRowIndex.HasValue && rowIndex > endRowIndex.Value)
-                                {
-                                    break;
-                                }
-
-                                // fill empty rows
-                                if (!_config.IgnoreEmptyRows)
-                                {
-                                    var expectedRowIndex = isFirstRow ? startRowIndex : nextRowIndex;
-                                    if (startRowIndex <= expectedRowIndex && expectedRowIndex < rowIndex)
-                                    {
-                                        for (int i = expectedRowIndex; i < rowIndex; i++)
-                                        {
-                                            yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                        }
-                                    }
-                                }
-
-                                // row -> c, must after `if (nextRowIndex < rowIndex)` condition code, eg. The first empty row has no xml element,and the second row xml element is <row r="2"/>
-                                if (!XmlReaderHelper.ReadFirstContent(reader) && !_config.IgnoreEmptyRows)
-                                {
-                                    //Fill in case of self closed empty row tag eg. <row r="1"/>
-                                    yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                    continue;
-                                }
-
-                                #region Set Cells
-
-                                var cell = GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
-                                var columnIndex = withoutCR ? -1 : 0;
-                                while (!reader.EOF)
-                                {
-                                    if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
-                                    {
-                                        var aS = reader.GetAttribute("s");
-                                        var aR = reader.GetAttribute("r");
-                                        var aT = reader.GetAttribute("t");
-                                        var cellValue = ReadCellAndSetColumnIndex(reader, ref columnIndex, withoutCR,
-                                            startColumnIndex, aR, aT);
-
-                                        if (_config.FillMergedCells)
-                                        {
-                                            if (_mergeCells.MergesValues.ContainsKey(aR))
-                                            {
-                                                _mergeCells.MergesValues[aR] = cellValue;
-                                            }
-                                            else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
-                                            {
-                                                _mergeCells.MergesValues.TryGetValue(mergeKey, out cellValue);
-                                            }
-                                        }
-
-                                        if (columnIndex < startColumnIndex || (endColumnIndex.HasValue && columnIndex > endColumnIndex.Value))
-                                            continue;
-
-                                        if (!string.IsNullOrEmpty(aS)) // if c with s meaning is custom style need to check type by xl/style.xml
-                                        {
-                                            int xfIndex = -1;
-                                            if (int.TryParse(aS, NumberStyles.Any, CultureInfo.InvariantCulture,
-                                                    out var styleIndex))
-                                                xfIndex = styleIndex;
-
-                                            // only when have s attribute then load styles xml data
-                                            if (_style == null)
-                                                _style = new ExcelOpenXmlStyles(_archive);
-
-                                            cellValue = _style.ConvertValueByStyleFormat(xfIndex, cellValue);
-                                        }
-
-                                        SetCellsValueAndHeaders(cellValue, useHeaderRow, ref headRows, ref isFirstRow, ref cell, columnIndex);
-                                    }
-                                    else if (!XmlReaderHelper.SkipContent(reader))
-                                        break;
-                                }
-
-                                #endregion
-
-                                if (isFirstRow)
-                                {
-                                    isFirstRow = false; // for startcell logic
-                                    if (useHeaderRow)
-                                        continue;
-                                }
-
-                                yield return cell;
-                            }
-                            else if (!XmlReaderHelper.SkipContent(reader))
-                            {
-                                break;
-                            }
-                        }
-                    }
-                    else if (!XmlReaderHelper.SkipContent(reader))
-                    {
-                        break;
-                    }
-                }
-            }
-        }
-
-#endif
 
         public IEnumerable<T> QueryRange<T>(string sheetName, string startCell, string endCell, bool hasHeader) where T : class, new()
         {
             return QueryImpl<T>(QueryRange(false, sheetName, startCell, endCell), startCell, hasHeader, this._config);
         }
 
-        public async Task<IEnumerable<IDictionary<string, object>>> QueryRangeAsync(bool useHeaderRow, string sheetName, string startCell, string endCell, CancellationToken cancellationToken = default)
+        public IEnumerable<IDictionary<string, object>> QueryRange(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex)
         {
-            return await Task.Run(() => Query(useHeaderRow, sheetName, startCell), cancellationToken).ConfigureAwait(false);
+            if (startRowIndex <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startRowIndex), "Start row index is 1-based and must be greater than 0.");
+            }
+            if (startColumnIndex <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startColumnIndex), "Start column index is 1-based and must be greater than 0.");
+            }
+            // convert to 0-based
+            startColumnIndex--;
+            startRowIndex--;
+
+            if (endRowIndex.HasValue)
+            {
+                if (endRowIndex.Value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(endRowIndex), "End row index is 1-based and must be greater than 0.");
+                }
+                // convert to 0-based
+                endRowIndex--;
+            }
+            if (endColumnIndex.HasValue)
+            {
+                if (endColumnIndex.Value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(endColumnIndex), "End column index is 1-based and must be greater than 0.");
+                }
+                // convert to 0-based
+                endColumnIndex--;
+            }
+
+            return InternalQueryRange(useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex);
         }
 
-        public async Task<IEnumerable<T>> QueryRangeAsync<T>(string sheetName, string startCell, string endCell, bool hasHeader = true, CancellationToken cancellationToken = default) where T : class, new()
+        public IEnumerable<T> QueryRange<T>(string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex, bool hasHeader) where T : class, new()
         {
-            return await Task.Run(() => Query<T>(sheetName, startCell, hasHeader), cancellationToken).ConfigureAwait(false);
+            return QueryImpl<T>(QueryRange(false, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex), ReferenceHelper.ConvertXyToCell(startColumnIndex, startRowIndex), hasHeader, _config);
+        }
+
+        internal IEnumerable<IDictionary<string, object>> InternalQueryRange(bool useHeaderRow, string sheetName, int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex)
+        {
+            // if sheets count > 1 need to read xl/_rels/workbook.xml.rels
+            var sheets = _archive.entries
+                .Where(w => w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) || w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            ZipArchiveEntry sheetEntry = null;
+            if (sheetName != null)
+            {
+                SetWorkbookRels(_archive.entries);
+                var sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetName);
+                if (sheetRecord == null)
+                {
+                    if (_config.DynamicSheets == null)
+                        throw new InvalidOperationException("Please check that parameters sheetName/Index are correct");
+
+                    var sheetConfig = _config.DynamicSheets.FirstOrDefault(ds => ds.Key == sheetName);
+                    if (sheetConfig != null)
+                    {
+                        sheetRecord = _sheetRecords.SingleOrDefault(s => s.Name == sheetConfig.Name);
+                    }
+                }
+                sheetEntry = sheets.Single(w => w.FullName == $"xl/{sheetRecord.Path}" || w.FullName == $"/xl/{sheetRecord.Path}" || w.FullName == sheetRecord.Path || sheetRecord.Path == $"/{w.FullName}");
+            }
+            else if (sheets.Length > 1)
+            {
+                SetWorkbookRels(_archive.entries);
+                var s = _sheetRecords[0];
+                sheetEntry = sheets.Single(w => w.FullName == $"xl/{s.Path}" || w.FullName == $"/xl/{s.Path}" || w.FullName.TrimStart('/') == s.Path.TrimStart('/'));
+            }
+            else
+                sheetEntry = sheets.Single();
+
+            // TODO: need to optimize performance
+            // Q. why need 3 times openstream merge one open read? A. no, zipstream can't use position = 0
+
+            if (_config.FillMergedCells)
+            {
+                if (!TryGetMergeCells(sheetEntry, out _mergeCells))
+                {
+                    yield break;
+                }
+            }
+
+            if (!TryGetMaxRowColumnIndex(sheetEntry, out var withoutCR, out var maxRowIndex, out var maxColumnIndex))
+            {
+                yield break;
+            }
+
+            if (endColumnIndex.HasValue)
+            {
+                maxColumnIndex = endColumnIndex.Value;
+            }
+
+            using (var sheetStream = sheetEntry.Open())
+            using (var reader = XmlReader.Create(sheetStream, _xmlSettings))
+            {
+                if (!XmlReaderHelper.IsStartElement(reader, "worksheet", _ns))
+                    yield break;
+
+                if (!XmlReaderHelper.ReadFirstContent(reader))
+                    yield break;
+
+                while (!reader.EOF)
+                {
+                    if (XmlReaderHelper.IsStartElement(reader, "sheetData", _ns))
+                    {
+                        if (!XmlReaderHelper.ReadFirstContent(reader))
+                            continue;
+
+                        var headRows = new Dictionary<int, string>();
+                        int rowIndex = -1;
+                        bool isFirstRow = true;
+                        while (!reader.EOF)
+                        {
+                            if (XmlReaderHelper.IsStartElement(reader, "row", _ns))
+                            {
+                                var nextRowIndex = rowIndex + 1;
+                                if (int.TryParse(reader.GetAttribute("r"), out int arValue))
+                                    rowIndex = arValue - 1; // The row attribute is 1-based
+                                else
+                                    rowIndex++;
+
+                                if (rowIndex < startRowIndex)
+                                {
+                                    XmlReaderHelper.ReadFirstContent(reader);
+                                    XmlReaderHelper.SkipToNextSameLevelDom(reader);
+                                    continue;
+                                }
+                                if (endRowIndex.HasValue && rowIndex > endRowIndex.Value)
+                                {
+                                    break;
+                                }
+
+                                // fill empty rows
+                                if (!_config.IgnoreEmptyRows)
+                                {
+                                    var expectedRowIndex = isFirstRow ? startRowIndex : nextRowIndex;
+                                    if (startRowIndex <= expectedRowIndex && expectedRowIndex < rowIndex)
+                                    {
+                                        for (int i = expectedRowIndex; i < rowIndex; i++)
+                                        {
+                                            yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
+                                        }
+                                    }
+                                }
+
+                                // row -> c, must after `if (nextRowIndex < rowIndex)` condition code, eg. The first empty row has no xml element,and the second row xml element is <row r="2"/>
+                                if (!XmlReaderHelper.ReadFirstContent(reader) && !_config.IgnoreEmptyRows)
+                                {
+                                    //Fill in case of self closed empty row tag eg. <row r="1"/>
+                                    yield return GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
+                                    continue;
+                                }
+
+                                #region Set Cells
+
+                                var cell = GetCell(useHeaderRow, maxColumnIndex, headRows, startColumnIndex);
+                                var columnIndex = withoutCR ? -1 : 0;
+                                while (!reader.EOF)
+                                {
+                                    if (XmlReaderHelper.IsStartElement(reader, "c", _ns))
+                                    {
+                                        var aS = reader.GetAttribute("s");
+                                        var aR = reader.GetAttribute("r");
+                                        var aT = reader.GetAttribute("t");
+                                        var cellValue = ReadCellAndSetColumnIndex(reader, ref columnIndex, withoutCR,
+                                            startColumnIndex, aR, aT);
+
+                                        if (_config.FillMergedCells)
+                                        {
+                                            if (_mergeCells.MergesValues.ContainsKey(aR))
+                                            {
+                                                _mergeCells.MergesValues[aR] = cellValue;
+                                            }
+                                            else if (_mergeCells.MergesMap.TryGetValue(aR, out var mergeKey))
+                                            {
+                                                _mergeCells.MergesValues.TryGetValue(mergeKey, out cellValue);
+                                            }
+                                        }
+
+                                        if (columnIndex < startColumnIndex || (endColumnIndex.HasValue && columnIndex > endColumnIndex.Value))
+                                            continue;
+
+                                        if (!string.IsNullOrEmpty(aS)) // if c with s meaning is custom style need to check type by xl/style.xml
+                                        {
+                                            int xfIndex = -1;
+                                            if (int.TryParse(aS, NumberStyles.Any, CultureInfo.InvariantCulture,
+                                                    out var styleIndex))
+                                                xfIndex = styleIndex;
+
+                                            // only when have s attribute then load styles xml data
+                                            if (_style == null)
+                                                _style = new ExcelOpenXmlStyles(_archive);
+
+                                            cellValue = _style.ConvertValueByStyleFormat(xfIndex, cellValue);
+                                        }
+
+                                        SetCellsValueAndHeaders(cellValue, useHeaderRow, ref headRows, ref isFirstRow, ref cell, columnIndex);
+                                    }
+                                    else if (!XmlReaderHelper.SkipContent(reader))
+                                        break;
+                                }
+
+                                #endregion
+
+                                if (isFirstRow)
+                                {
+                                    isFirstRow = false; // for startcell logic
+                                    if (useHeaderRow)
+                                        continue;
+                                }
+
+                                yield return cell;
+                            }
+                            else if (!XmlReaderHelper.SkipContent(reader))
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    else if (!XmlReaderHelper.SkipContent(reader))
+                    {
+                        break;
+                    }
+                }
+            }
         }
 
         public static IEnumerable<T> QueryImpl<T>(IEnumerable<IDictionary<string, object>> values, string startCell, bool hasHeader, Configuration configuration) where T : class, new()
@@ -1087,7 +562,7 @@ namespace MiniExcelLibs.OpenXml
                 newColumnIndex = columnIndex + 1;
 
             //TODO:need to check only need nextColumnIndex or columnIndex
-            else if (ReferenceHelper.TryParseReference(aR, out int referenceColumn, out _))
+            else if (ReferenceHelper.ParseReference(aR, out int referenceColumn, out _))
                 newColumnIndex = referenceColumn - 1; // ParseReference is 1-based
             else
                 newColumnIndex = columnIndex;
@@ -1242,7 +717,7 @@ namespace MiniExcelLibs.OpenXml
                             var r = reader.GetAttribute("r");
                             if (r != null)
                             {
-                                if (ReferenceHelper.TryParseReference(r, out var column, out var row))
+                                if (ReferenceHelper.ParseReference(r, out var column, out var row))
                                 {
                                     column--;
                                     row--;
@@ -1264,7 +739,7 @@ namespace MiniExcelLibs.OpenXml
                                 throw new InvalidDataException("No dimension data found for the sheet");
 
                             var rs = refAttr.Split(':');
-                            if (!ReferenceHelper.TryParseReference(rs.Length == 2 ? rs[1] : rs[0], out var col, out var row))
+                            if (!ReferenceHelper.ParseReference(rs.Length == 2 ? rs[1] : rs[0], out var col, out var row))
                                 throw new InvalidDataException("The dimensions of the sheet are invalid");
 
                             maxColumnIndex = col;
@@ -1358,7 +833,7 @@ namespace MiniExcelLibs.OpenXml
                         var r = reader.GetAttribute("r");
                         if (r != null)
                         {
-                            if (ReferenceHelper.TryParseReference(r, out var column, out var row))
+                            if (ReferenceHelper.ParseReference(r, out var column, out var row))
                             {
                                 column--;
                                 row--;
@@ -1382,7 +857,7 @@ namespace MiniExcelLibs.OpenXml
                         var rs = refAttr.Split(':');
 
                         // issue : https://github.com/mini-software/MiniExcel/issues/102
-                        if (!ReferenceHelper.TryParseReference(rs.Length == 2 ? rs[1] : rs[0], out int cIndex, out int rIndex))
+                        if (!ReferenceHelper.ParseReference(rs.Length == 2 ? rs[1] : rs[0], out int cIndex, out int rIndex))
                             throw new InvalidDataException("The dimensions of the sheet are invalid");
 
                         maxRowIndex = rIndex - 1;
@@ -1477,8 +952,8 @@ namespace MiniExcelLibs.OpenXml
                             if (refs.Length == 1)
                                 continue;
 
-                            ReferenceHelper.TryParseReference(refs[0], out var x1, out var y1);
-                            ReferenceHelper.TryParseReference(refs[1], out var x2, out var y2);
+                            ReferenceHelper.ParseReference(refs[0], out var x1, out var y1);
+                            ReferenceHelper.ParseReference(refs[1], out var x2, out var y2);
 
                             mergeCells.MergesValues.Add(refs[0], null);
 

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -136,12 +136,9 @@ namespace MiniExcelLibs.OpenXml
             // TODO: need to optimize performance
             // Q. why need 3 times openstream merge one open read? A. no, zipstream can't use position = 0
 
-            if (_config.FillMergedCells)
+            if (_config.FillMergedCells && !TryGetMergeCells(sheetEntry, out _mergeCells))
             {
-                if (!TryGetMergeCells(sheetEntry, out _mergeCells))
-                {
-                    yield break;
-                }
+                yield break;
             }
 
             if (!TryGetMaxRowColumnIndex(sheetEntry, out var withoutCR, out var maxRowIndex, out var maxColumnIndex))

--- a/src/MiniExcel/Utils/ReferenceHelper.cs
+++ b/src/MiniExcel/Utils/ReferenceHelper.cs
@@ -56,7 +56,7 @@ namespace MiniExcelLibs.Utils
         /// <param name="value">The value.</param>
         /// <param name="column">The column, 1-based.</param>
         /// <param name="row">The row, 1-based.</param>
-        public static bool ParseReference(string value, out int column, out int row)
+        public static bool TryParseReference(string value, out int column, out int row)
         {
             row = 0;
             column = 0;
@@ -93,7 +93,7 @@ namespace MiniExcelLibs.Utils
             if (position == 0)
                 return false;
 
-            return int.TryParse(value.Substring(position), NumberStyles.None, CultureInfo.InvariantCulture, out row);
+            return int.TryParse(value.Substring(position), NumberStyles.None, CultureInfo.InvariantCulture, out row) && row > 0;
         }
     }
 }

--- a/src/MiniExcel/Utils/ReferenceHelper.cs
+++ b/src/MiniExcel/Utils/ReferenceHelper.cs
@@ -56,7 +56,7 @@ namespace MiniExcelLibs.Utils
         /// <param name="value">The value.</param>
         /// <param name="column">The column, 1-based.</param>
         /// <param name="row">The row, 1-based.</param>
-        public static bool TryParseReference(string value, out int column, out int row)
+        public static bool ParseReference(string value, out int column, out int row)
         {
             row = 0;
             column = 0;

--- a/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcelTests/MiniExcelOpenXmlTests.cs
@@ -95,7 +95,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         const string path = "../../../../../samples/xlsx/TestCustomExcelColumnAttribute.xlsx";
         var rows = MiniExcel.Query<ExcelAttributeDemo>(path).ToList();
-        
+
         Assert.Equal("Column1", rows[0].Test1);
         Assert.Equal("Column2", rows[0].Test2);
         Assert.Null(rows[0].Test3);
@@ -117,11 +117,11 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
                 Test3 = "Test3",
                 Test4 = "Test4",
             });
-        
+
         MiniExcel.SaveAs(path.ToString(), input);
         var rows = MiniExcel.Query(path.ToString(), true).ToList();
         var first = rows[0] as IDictionary<string, object>;
-        
+
         Assert.Equal(3, rows.Count);
         Assert.Equal(["Column1", "Column2", "Test5", "Test7", "Test6", "Test4"], first?.Keys);
         Assert.Equal("Test1", rows[0].Column1);
@@ -159,11 +159,35 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         var rows = MiniExcel.QueryRange(path, startCell: "A2", endCell: "C7")
             .Cast<IDictionary<string, object>>()
             .ToList();
-        
+
         Assert.Equal(5, rows.Count);
         Assert.Equal(3, rows[0].Count);
         Assert.Equal(2d, rows[1]["B"]);
         Assert.Equal(null!, rows[2]["A"]);
+
+        var startCellXY = MiniExcelLibs.Utils.ReferenceHelper.ConvertCellToXY("A2");
+        var endCellXY = MiniExcelLibs.Utils.ReferenceHelper.ConvertCellToXY("C7");
+        rows = MiniExcel.QueryRange(path, startRowIndex: startCellXY.Item2, startColumnIndex: startCellXY.Item1, endRowIndex: endCellXY.Item2, endColumnIndex: endCellXY.Item1)
+            .Cast<IDictionary<string, object>>()
+            .ToList();
+        Assert.Equal(5, rows.Count);
+        Assert.Equal(3, rows[0].Count);
+        Assert.Equal(2d, rows[1]["B"]);
+        Assert.Equal(null!, rows[2]["A"]);
+
+        rows = MiniExcel.QueryRange(path, startRowIndex:2, startColumnIndex: 1, endRowIndex: 3)
+          .Cast<IDictionary<string, object>>()
+          .ToList();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(4, rows[0].Count);
+        Assert.Equal(4d, rows[1]["D"]);
+
+        rows = MiniExcel.QueryRange(path, startRowIndex: 2, startColumnIndex: 1, endColumnIndex: 3)
+        .Cast<IDictionary<string, object>>()
+        .ToList();
+        Assert.Equal(5, rows.Count);
+        Assert.Equal(3, rows[0].Count);
+        Assert.Equal(3d, rows[3]["C"]);
     }
 
     [Fact]
@@ -235,7 +259,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
             Assert.Equal(4, rows[4].d);
         }
     }
-        
+
     [Fact]
     public void TestEmptyRowsQuerySelfClosingTag()
     {
@@ -393,13 +417,13 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         Assert.Equal("sagittis.lobortis@leoMorbi.com", rows[4].Mail);
         Assert.Equal(8209.76m, rows[4].Points);
     }
-        
+
     [Fact]
     public void TestDatetimeSpanFormat_ClosedXml()
     {
         const string path = "../../../../../samples/xlsx/TestDatetimeSpanFormat_ClosedXml.xlsx";
         using var stream = FileHelper.OpenRead(path);
-        
+
         var row = stream.Query().First();
         var a = row.A;
         var b = row.B;
@@ -435,13 +459,13 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
         using var fs = File.OpenRead(path);
-        using var reader = ExcelDataReader. ExcelReaderFactory.CreateReader(fs);
+        using var reader = ExcelDataReader.ExcelReaderFactory.CreateReader(fs);
         var exceldatareaderResult = reader.AsDataSet();
 
         using var stream = File.OpenRead(path);
         var rows = stream.Query().ToList();
         Assert.Equal(exceldatareaderResult.Tables[0].Rows.Count, rows.Count);
-        
+
         foreach (IDictionary<string, object?> row in rows)
         {
             var rowIndex = rows.IndexOf(row);
@@ -509,14 +533,14 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         {
             using var file = AutoDeletingPath.Create();
             var path = file.ToString();
-            
+
             List<SaveAsFileWithDimensionByICollectionTestType> values =
             [
                 new() { A = "A", B = "B" },
                 new() { A = "A", B = "B" }
             ];
             MiniExcel.SaveAs(path, values);
-            
+
             using (var stream = File.OpenRead(path))
             {
                 var rows = stream.Query(useHeaderRow: false).ToList();
@@ -543,7 +567,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
             using var file = AutoDeletingPath.Create();
             var path = file.ToString();
             List<SaveAsFileWithDimensionByICollectionTestType> values = [];
-            
+
             MiniExcel.SaveAs(path, values, false);
             {
                 using (var stream = File.OpenRead(path))
@@ -610,7 +634,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         {
             using var file = AutoDeletingPath.Create();
             var path = file.ToString();
-            
+
             var table = new DataTable();
             MiniExcel.SaveAs(path, table);
             Assert.Equal("A1", Helpers.GetFirstSheetDimensionRefValue(path));
@@ -627,7 +651,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         {
             using var file = AutoDeletingPath.Create();
             var path = file.ToString();
-            
+
             var table = new DataTable();
             table.Columns.Add("a", typeof(string));
             table.Columns.Add("b", typeof(decimal));
@@ -635,10 +659,10 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
             table.Columns.Add("d", typeof(DateTime));
             table.Rows.Add(@"""<>+-*//}{\\n", 1234567890);
             table.Rows.Add("<test>Hello World</test>", -1234567890, false, DateTime.Now);
-            
+
             MiniExcel.SaveAs(path, table);
             Assert.Equal("A1:D3", Helpers.GetFirstSheetDimensionRefValue(path));
-            
+
             using (var stream = File.OpenRead(path))
             {
                 var rows = stream.Query(useHeaderRow: true).ToList();
@@ -666,12 +690,12 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         //TODO:StartCell
         {
             using var path = AutoDeletingPath.Create();
-            
+
             var table = new DataTable();
             table.Columns.Add("a", typeof(string));
             table.Rows.Add("A");
             table.Rows.Add("B");
-            
+
             MiniExcel.SaveAs(path.ToString(), table);
             Assert.Equal("A1:A3", Helpers.GetFirstSheetDimensionRefValue(path.ToString()));
         }
@@ -761,7 +785,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         using var file = AutoDeletingPath.Create();
         var path = file.ToString();
-        
+
         {
             var values = new List<Dictionary<string, object>>
             {
@@ -835,7 +859,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         using var path = AutoDeletingPath.Create();
         MiniExcel.SaveAs(
             path.ToString(),
-            new[] 
+            new[]
             {
                 new { Column1 = "MiniExcel", Column2 = 1 },
                 new { Column1 = "Github", Column2 = 2 }
@@ -881,7 +905,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         using var file = AutoDeletingPath.Create();
         var path = file.ToString();
-        
+
         // Dapper Query
         using (var connection = Db.GetConnection("Data Source=:memory:"))
         {
@@ -1039,13 +1063,13 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     public void SaveAsBasicCreateTest()
     {
         using var path = AutoDeletingPath.Create();
-        
-        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[] 
+
+        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[]
         {
             new { Column1 = "MiniExcel", Column2 = 1 },
             new { Column1 = "Github", Column2 = 2}
         });
-        
+
         Assert.Single(rowsWritten);
         Assert.Equal(2, rowsWritten[0]);
 
@@ -1067,7 +1091,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         {
             using var path = AutoDeletingPath.Create();
-            var values = new[] 
+            var values = new[]
             {
                 new { Column1 = "MiniExcel", Column2 = 1 },
                 new { Column1 = "Github", Column2 = 2 }
@@ -1091,7 +1115,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         }
         {
             using var path = AutoDeletingPath.Create();
-            var values = new[] 
+            var values = new[]
             {
                 new { Column1 = "MiniExcel", Column2 = 1 },
                 new { Column1 = "Github", Column2 = 2}
@@ -1122,14 +1146,14 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     public void SaveAsSpecialAndTypeCreateTest()
     {
         using var path = AutoDeletingPath.Create();
-        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[] 
+        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[]
         {
             new { a = @"""<>+-*//}{\\n", b = 1234567890, c = true, d = DateTime.Now },
             new { a = "<test>Hello World</test>", b = -1234567890, c = false, d = DateTime.Now.Date }
         });
         Assert.Single(rowsWritten);
         Assert.Equal(2, rowsWritten[0]);
-            
+
         var info = new FileInfo(path.ToString());
         Assert.True(info.FullName == path.ToString());
     }
@@ -1166,12 +1190,12 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         var now = DateTime.Now;
         using var path = AutoDeletingPath.Create();
-        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[] 
+        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[]
         {
             new { a = @"""<>+-*//}{\\n", b = 1234567890, c = true, d = now },
             new { a = "<test>Hello World</test>", b = -1234567890, c = false, d = now.Date }
         }, sheetName: "R&D");
-        
+
         Assert.Single(rowsWritten);
         Assert.Equal(2, rowsWritten[0]);
 
@@ -1196,7 +1220,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     {
         var now = DateTime.Now;
         using var path = AutoDeletingPath.Create();
-        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[] 
+        var rowsWritten = MiniExcel.SaveAs(path.ToString(), new[]
         {
             new { a = @"""<>+-*//}{\\n", b = 1234567890, c = true, d= now },
             new { a = "<test>Hello World</test>", b = -1234567890, c = false, d = now.Date }
@@ -1208,7 +1232,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         var allParts = zip.GetParts()
             .Select(s => new { s.CompressionOption, s.ContentType, s.Uri, s.Package.GetType().Name })
             .ToDictionary(s => s.Uri.ToString(), s => s);
-                
+
         Assert.True(allParts["/xl/styles.xml"].ContentType == "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
         Assert.True(allParts["/xl/workbook.xml"].ContentType == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
         Assert.True(allParts["/xl/worksheets/sheet1.xml"].ContentType == "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
@@ -1241,7 +1265,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         _ = MiniExcel.Query(path, configuration: new OpenXmlConfiguration { EnableSharedStringCache = true }).First();
         using var currentProcess = Process.GetCurrentProcess();
         var totalBytesOfMemoryUsed = currentProcess.WorkingSet64;
-        
+
         _output.WriteLine("totalBytesOfMemoryUsed: " + totalBytesOfMemoryUsed);
         _output.WriteLine("elapsedMilliseconds: " + Stopwatch.GetElapsedTime(ts).TotalMilliseconds);
     }
@@ -1265,7 +1289,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         using var path = AutoDeletingPath.Create();
         var dateTime = DateTime.Now;
         var onlyDate = DateOnly.FromDateTime(dateTime);
-        
+
         var table = new DataTable();
         table.Columns.Add("Column1", typeof(string));
         table.Columns.Add("Column2", typeof(int));
@@ -1332,7 +1356,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         using var path = AutoDeletingPath.Create();
         var dateTime = DateTime.Now;
         var onlyDate = DateOnly.FromDateTime(dateTime);
-        
+
         var table = new DataTable();
         table.Columns.Add("Column1", typeof(string));
         table.Columns.Add("Column2", typeof(int));
@@ -1400,7 +1424,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         var now = DateTime.Now;
         using var file = AutoDeletingPath.Create();
         var path = file.ToString();
-        
+
         {
             var table = new DataTable();
             table.Columns.Add("a", typeof(string));
@@ -1474,9 +1498,9 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
                     }
                 ]
             }, overwriteSheet: true);
-            
+
             Assert.Equal(1, rowsWritten);
-            
+
             using var p = new ExcelPackage(new FileInfo(path));
             var sheet2 = p.Workbook.Worksheets[1];
 
@@ -1524,7 +1548,7 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
             Assert.True(sheet3.Name == "Sheet3");
         }
     }
-    
+
     private class DateOnlyTest
     {
         public DateOnly Date { get; set; }
@@ -1535,11 +1559,11 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     public void DateOnlySupportTest()
     {
         var query = MiniExcel.Query<DateOnlyTest>(PathHelper.GetFile("xlsx/TestDateOnlyMapping.xlsx")).ToList();
-        
+
         Assert.Equal(new DateOnly(2020, 9, 27), query[0].Date);
         Assert.Equal(new DateOnly(2020, 10, 25), query[1].Date);
         Assert.Equal(new DateOnly(2021, 10, 4), query[2].Date);
-        
+
         Assert.Equal(new DateOnly(2020, 9, 27), query[0].DateWithFormat);
         Assert.Equal(new DateOnly(2020, 10, 25), query[1].DateWithFormat);
         Assert.Equal(new DateOnly(2020, 6, 1), query[7].DateWithFormat);
@@ -1568,13 +1592,13 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
         Assert.Equal(1, dim2[0].Columns.StartIndex);
         Assert.Equal(7, dim2[0].Columns.EndIndex);
     }
-    
+
     [Fact]
     public void SheetDimensionsTest_MultiSheet()
     {
         var path = PathHelper.GetFile("xlsx/TestMultiSheet.xlsx");
         var dim = MiniExcel.GetSheetDimensions(path);
-        
+
         Assert.Equal("A1", dim[0].StartCell);
         Assert.Equal("D12", dim[0].EndCell);
         Assert.Equal(12, dim[0].Rows.Count);


### PR DESCRIPTION
Summary:
1. Merged duplicated logic between `Query` and `QueryRange`. `Query` is essentially a `QueryRange` with only a start cell and no end cell. Previously, there was a lot of duplicated code, and some key logic was missing in `QueryRange`. Now they are merged to improve code reuse.
2. Added support for new parameters in `QueryRange: int startRowIndex, int startColumnIndex, int? endRowIndex, int? endColumnIndex`
    - `start` parameters are required, while `end` parameters are optional
    - For `end`, you can specify only `endRowIndex`, only `endColumnIndex`, or both. If only `endRowIndex` is set, it will include all columns (it depends on the largest column of the data, not the largest column in Excel). If only `endColumnIndex` is set, it will include all rows (it depends on the largest row of the data, not the largest row in Excel).
3.  This PR resolves part of #763
    - Previously, `var rows = MiniExcel.QueryRange(path, startCell: "A1", endCell: "J1");` would return all rows. Now it correctly returns only one row: A1-J1
    - Dummy number is no provided. We can achieve similar behavior by omitting `endRowIndex` or `endColumnIndex`, and use `ReferenceHelper.ConvertXyToCell` / `ReferenceHelper.ConvertCellToXy` for helper conversions
    - I don't recommend using a parameter style like `startRowNumber: 2, endRowNumber: 500, startColumn: "A", endColumn: "J"`, where strings and integers are mixed. Either strictly use cell string format (e.g., A1) or uniformly use integers to specify indexes.
 
Next TODO:
1. Implement truly asynchronous methods — current async support is not ideal
2. Add CSV support for `QueryRange`. Honestly, supporting CSV in this library wasn't the best decision. The codebase has many awkward designs due to CSV support, but we can't go back now.