### PR TITLE
Remove .NET 9 and add .NET 10; remove .NET Framework 4.6.2 which is still being covered by .NET standard 2.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       
-    - name: Setup .NET 9
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: | 
+          8.0.x
+          10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,14 +13,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Setup .NET 8
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
-    - name: Setup .NET 9
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
+        dotnet-version: | 
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
       env:

--- a/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
+++ b/benchmarks/MiniExcel.Benchmarks/MiniExcel.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>

--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<Version>2.0.0-beta.1</Version>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<LangVersion>13</LangVersion>
 	</PropertyGroup>
 	
@@ -40,10 +40,7 @@ Todo : https://github.com/mini-software/MiniExcel/projects/1?fullscreen=true</De
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net462'">
-		<Reference Include="System.IO.Compression" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net462'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 	  <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0" />
 	  <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
 	</ItemGroup>

--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<Version>2.0.0-beta.1</Version>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -172,7 +172,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
             maxColumnIndex = endColumnIndex.Value;
         }
 
+#if NET10_0_OR_GREATER
+        using var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
         using var sheetStream = sheetEntry.Open();
+#endif
         using var reader = XmlReader.Create(sheetStream, xmlSettings);
 
         if (!XmlReaderHelper.IsStartElement(reader, "worksheet", Ns))
@@ -491,7 +495,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
             return;
         
         var idx = 0;
+#if NET10_0_OR_GREATER
+        using var stream = await sharedStringsEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
         using var stream = sharedStringsEntry.Open();
+#endif
         if (_config.EnableSharedStringCache && sharedStringsEntry.Length >= _config.SharedStringCacheSize)
         {
             SharedStrings = new SharedStringsDiskCache();
@@ -525,8 +533,13 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
             true
 #endif
         );
-        
-        using var stream = entries.Single(w => w.FullName == "xl/workbook.xml").Open();
+
+        var entry = entries.Single(w => w.FullName == "xl/workbook.xml");
+#if NET10_0_OR_GREATER
+            using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
+        using var stream = entry.Open();
+#endif
         using var reader = XmlReader.Create(stream, xmlSettings);
         
         if (!XmlReaderHelper.IsStartElement(reader, "workbook", Ns))
@@ -616,7 +629,12 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
             .CreateListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        using var stream = entries.Single(w => w.FullName == "xl/_rels/workbook.xml.rels").Open();
+        var entry = entries.Single(w => w.FullName == "xl/_rels/workbook.xml.rels");
+#if NET10_0_OR_GREATER
+            using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
+        using var stream = entry.Open();
+#endif
         using var reader = XmlReader.Create(stream, xmlSettings);
         
         if (!XmlReaderHelper.IsStartElement(reader, "Relationships", "http://schemas.openxmlformats.org/package/2006/relationships"))
@@ -836,7 +854,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 
             var withoutCr = false;
 
+#if NET10_0_OR_GREATER
+            using (var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false))
+#else
             using (var sheetStream = sheet.Open())
+#endif
             using (var reader = XmlReader.Create(sheetStream, xmlSettings))
             {
                 while (await reader.ReadAsync().ConfigureAwait(false))
@@ -884,7 +906,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 
             if (withoutCr)
             {
+#if NET10_0_OR_GREATER
+                using var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
                 using var sheetStream = sheet.Open();
+#endif
                 using var reader = XmlReader.Create(sheetStream, xmlSettings);
                 
                 if (!XmlReaderHelper.IsStartElement(reader, "worksheet", Ns))
@@ -978,7 +1004,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
         bool withoutCr = false;
         int maxRowIndex = -1;
         int maxColumnIndex = -1;
+#if NET10_0_OR_GREATER
+        using (var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false))
+#else
         using (var sheetStream = sheetEntry.Open())
+#endif
         using (var reader = XmlReader.Create(sheetStream, xmlSettings))
         {
             while (await reader.ReadAsync()
@@ -1028,7 +1058,11 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 
         if (withoutCr)
         {
+#if NET10_0_OR_GREATER
+            using var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
             using var sheetStream = sheetEntry.Open();
+#endif
             using var reader = XmlReader.Create(sheetStream, xmlSettings);
             
             if (!XmlReaderHelper.IsStartElement(reader, "worksheet", Ns))
@@ -1101,8 +1135,12 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 #endif
         );
         var mergeCells = new MergeCells();
-        
+
+#if NET10_0_OR_GREATER
+        using var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
         using var sheetStream = sheetEntry.Open();
+#endif
         using var reader = XmlReader.Create(sheetStream, xmlSettings);
         
         if (!XmlReaderHelper.IsStartElement(reader, "worksheet", Ns))

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -536,7 +536,7 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 
         var entry = entries.Single(w => w.FullName == "xl/workbook.xml");
 #if NET10_0_OR_GREATER
-            using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
 #else
         using var stream = entry.Open();
 #endif
@@ -631,7 +631,7 @@ internal partial class ExcelOpenXmlSheetReader : IExcelReader
 
         var entry = entries.Single(w => w.FullName == "xl/_rels/workbook.xml.rels");
 #if NET10_0_OR_GREATER
-            using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
 #else
         using var stream = entry.Open();
 #endif

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -78,7 +78,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
         }
         finally
         {
+#if NET10_0_OR_GREATER
+            await _archive.DisposeAsync().ConfigureAwait(false);
+#else
             _archive.Dispose();
+#endif
         }
     }
 
@@ -156,7 +160,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
         }
         finally
         {
+#if NET10_0_OR_GREATER
+            await _archive.DisposeAsync().ConfigureAwait(false);
+#else
             _archive.Dispose();
+#endif
         }
     }
 
@@ -176,7 +184,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
         var entry = _archive.CreateEntry(sheetPath, CompressionLevel.Fastest);
         var rowsWritten = 0;
 
+#if NET10_0_OR_GREATER
+        using var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
         using var zipStream = entry.Open();
+#endif
         using var writer = new MiniExcelStreamWriter(zipStream, Utf8WithBom, _configuration.BufferSize);
         
         if (values is null)
@@ -597,7 +609,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
         }
 #if NET5_0_OR_GREATER
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
-        await using var stream = contentTypesZipEntry.Open();
+#if NET10_0_OR_GREATER
+            await using var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
+            await using var stream = contentTypesZipEntry.Open();
+#endif
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
 #else
         using var stream = contentTypesZipEntry.Open();
@@ -645,7 +661,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
 
 #if NET5_0_OR_GREATER
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
+#if NET10_0_OR_GREATER
+        await using (var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false))
+#else
         await using (var zipStream = entry.Open())
+#endif
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
 #else
         using (var zipStream = entry.Open())
@@ -666,7 +686,11 @@ internal partial class ExcelOpenXmlSheetWriter : IExcelWriter
 
 #if NET5_0_OR_GREATER
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
+#if NET10_0_OR_GREATER
+        await using var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
         await using var zipStream = entry.Open();
+#endif
         await zipStream.WriteAsync(content, cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
 #else

--- a/src/MiniExcel/Picture/MiniExcelPictureImplement.cs
+++ b/src/MiniExcel/Picture/MiniExcelPictureImplement.cs
@@ -145,8 +145,17 @@ internal static partial class MiniExcelPictureImplement
                 var imageName = $"image{Guid.NewGuid():N}.png";
                 var imagePath = $"xl/media/{imageName}";
                 var imageEntry = archive.CreateEntry(imagePath);
-                    
-                using (var entryStream = imageEntry.Open())
+
+#if NET10_0_OR_GREATER
+                using var entryStream = await imageEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
+                using var entryStream = imageEntry.Open();
+#endif
+#if NET5_0_OR_GREATER
+                await entryStream.WriteAsync(imageBytes.AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
+                await entryStream.WriteAsync(imageBytes, 0, imageBytes.Length, cancellationToken).ConfigureAwait(false);
+#endif
                 {
 #pragma warning disable CA1835
                     await entryStream.WriteAsync(imageBytes, 0, imageBytes.Length, CancellationToken.None).ConfigureAwait(false);

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.MergeCells.cs
@@ -55,15 +55,27 @@ internal partial class ExcelOpenXmlTemplate
             _xMergeCellInfos = [];
             _newXMergeCellInfos = [];
 
+#if NET10_0_OR_GREATER
+            var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
             var sheetStream = sheet.Open();
+#endif
             var fullName = sheet.FullName;
 
             var entry = archive.ZipFile.CreateEntry(fullName);
+#if NET10_0_OR_GREATER
+            using var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
+#else
             using var zipStream = entry.Open();
+#endif
             await GenerateSheetXmlImplByUpdateModeAsync(sheet, zipStream, sheetStream, new Dictionary<string, object>(), sharedStrings, mergeCells: true, cancellationToken).ConfigureAwait(false);
             //doc.Save(zipStream); //don't do it beacause: https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png
         }
 
+#if NET10_0_OR_GREATER
+        await archive.ZipFile.DisposeAsync().ConfigureAwait(false);
+#else
         archive.ZipFile.Dispose();
+#endif
     }
 }

--- a/tests/MiniExcelTests/MiniExcelTests.csproj
+++ b/tests/MiniExcelTests/MiniExcelTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		

--- a/tests/MiniExcelTests/MiniExcelTests.csproj
+++ b/tests/MiniExcelTests/MiniExcelTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		


### PR DESCRIPTION
There is no reason to target the library to .NET 9 since there is no code specific to that target (no #if NET9_0_OR_GREATER)