### PR TITLE
PR 870 oversight fix

### DIFF
--- a/src/MiniExcel.Core/Reflection/MiniExcelMapper.cs
+++ b/src/MiniExcel.Core/Reflection/MiniExcelMapper.cs
@@ -156,7 +156,9 @@ public static partial class MiniExcelMapper
                     if (config.DateOnlyConversionMode == DateOnlyConversionMode.RequireMidnight && dateTimeValue.TimeOfDay != TimeSpan.Zero)
                         throw new InvalidCastException($"Could not convert cell of type DateTime to DateOnly, because DateTime was not at midnight, but at {dateTimeValue:HH:mm:ss}.");
 
-                    return DateOnly.FromDateTime(dateTimeValue);
+                    newValue = DateOnly.FromDateTime(dateTimeValue);
+                    pInfo.Property.SetValue(v, newValue);
+                    return newValue;
                 }
 
                 var vs = itemValue?.ToString();

--- a/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
@@ -3681,7 +3681,8 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
         {
             try
             {
-                _ = testFn();
+                var result = testFn();
+                Assert.Equal(new DateOnly(2025, 1, 1), result[0].Date);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes an oversight in #870 due to which DateOnly values were extracted but not correctly assigned.