### PR TITLE
Fixed exception not being thrown when too long a sheet name was passed as dictionary key

### DIFF
--- a/src/MiniExcel.Core/Helpers/ThrowHelper.cs
+++ b/src/MiniExcel.Core/Helpers/ThrowHelper.cs
@@ -2,6 +2,9 @@
 
 internal static class ThrowHelper
 {
+    private static readonly byte[] ZipArchiveHeader = [0x50, 0x4B];
+    private const int ExcelMaxSheetNameLength = 31;
+    
     internal static void ThrowIfInvalidOpenXml(Stream stream)
     {
         var probe = new byte[8];
@@ -13,7 +16,16 @@ internal static class ThrowHelper
         stream.Seek(0, SeekOrigin.Begin);
 
         // OpenXml format can be any ZIP archive
-        if (probe is not [0x50, 0x4B, ..])
+        if (!probe.StartsWith(ZipArchiveHeader))
             throw new InvalidDataException("The file is not a valid OpenXml document.");
+    }
+
+    internal static void ThrowIfInvalidSheetName(string? sheetName)
+    {
+        if (string.IsNullOrEmpty(sheetName))
+            throw new ArgumentException("Sheet names cannot be empty or null");
+
+        if (sheetName.Length > ExcelMaxSheetNameLength)
+            throw new ArgumentException("Sheet names must be less than 31 characters");
     }
 }

--- a/src/MiniExcel.Core/OpenXml/OpenXmlWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel.Core/OpenXml/OpenXmlWriter.DefaultOpenXml.cs
@@ -17,6 +17,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         {
             foreach (var sheet in dictionary)
             {
+                ThrowHelper.ThrowIfInvalidSheetName(sheet.Key);
+                
                 sheetId++;
                 var sheetInfos = GetSheetInfos(sheet.Key);
                 yield return Tuple.Create(sheetInfos.ToDto(sheetId), sheet.Value);

--- a/src/MiniExcel.Core/OpenXml/OpenXmlWriter.cs
+++ b/src/MiniExcel.Core/OpenXml/OpenXmlWriter.cs
@@ -45,10 +45,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
     [CreateSyncVersion]
     internal static Task<OpenXmlWriter> CreateAsync(Stream stream, object? value, string? sheetName,  bool printHeader, IMiniExcelConfiguration? configuration, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(sheetName))
-            throw new ArgumentException("Sheet names cannot be empty or null", nameof(sheetName));
-        if (sheetName?.Length > 31)
-            throw new ArgumentException("Sheet names must be less than 31 characters", nameof(sheetName));
+        ThrowHelper.ThrowIfInvalidSheetName(sheetName);
         
         var writer = new OpenXmlWriter(stream, value, sheetName, configuration, printHeader);
         return Task.FromResult(writer);

--- a/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
@@ -3690,4 +3690,24 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
             }
         }
     }
+
+    [Fact]
+    public void TestIssue876()
+    {
+        var someTable = new[] 
+        {
+            new { Name = "Jack", Age = 25 }, 
+        };
+
+        var sheets = new Dictionary<string, object>
+        {
+            ["SomeVeryLongNameWithMoreThan31Characters"] = someTable
+        };
+
+        Assert.Throws<ArgumentException>(() =>
+        {
+            using var outputPath = AutoDeletingPath.Create();
+            _excelExporter.Export(outputPath.ToString(), sheets);
+        });
+    }
 }


### PR DESCRIPTION
Resolves #876 